### PR TITLE
fix: resolve critical MCP query and conversation failures (#31)

### DIFF
--- a/mcp_server/database.py
+++ b/mcp_server/database.py
@@ -109,17 +109,19 @@ def _load_embedding_model() -> None:
 
 
 def initialize_embedding_model_async() -> None:
-    global _embedding_model_loading
+    global _embedding_model_loading, _embedding_model_load_error
     with _embedding_model_lock:
-        if _embedding_model is not None or _embedding_model_loading or _embedding_model_load_error is not None:
+        if _embedding_model is not None or _embedding_model_loading:
             return
+        if _embedding_model_load_error is not None:
+            _embedding_model_load_error = None
         _embedding_model_loading = True
         thread = threading.Thread(target=_load_embedding_model, name="embedding-model-loader", daemon=True)
         thread.start()
 
 
 def _get_embedding_model():
-    global _embedding_model_loading
+    global _embedding_model_loading, _embedding_model_load_error
     with _embedding_model_lock:
         if _embedding_model is not None:
             return _embedding_model
@@ -530,20 +532,20 @@ def query_email_database(
         except Exception as e:
             close_connection()
             return {"error": f"Failed to encode semantic query: {e}", "results": []}
-        
-        sql = """
+
+        sql = f"""
             SELECT e.id, e.thread_id, e.subject, e.timestamp, e.sender as from_address,
                    e.from_name, e.category_tags, e.project_tags, e.has_attachments, e.folder,
                    COALESCE(e.body_text, e.body_markdown) as body_text,
                    vec_distance_cosine(ev.embedding, ?) as relevance_score
             FROM emails e
             JOIN email_vectors ev ON e.id = ev.email_id
-            WHERE (e.source IS NULL OR e.source != 'quoted_reply')
+            WHERE {where_sql}
             ORDER BY relevance_score ASC
             LIMIT ?
         """
-        semantic_params = [query_embedding, limit]
-        
+        semantic_params = [query_embedding] + list(params) + [limit]
+
         cursor_conn.execute(sql, semantic_params)
         results = cursor_conn.fetchall()
         

--- a/mcp_server/database.py
+++ b/mcp_server/database.py
@@ -290,9 +290,18 @@ def get_email(email_id: str) -> Optional[EmailRecord]:
 def get_conversation(thread_id: str) -> Optional[ConversationThread]:
     conn = get_connection()
     cursor = conn.cursor()
+
+    conversation_columns = """
+        id, message_id, thread_id, subject_thread_key, timestamp,
+        from_address, from_name, to_addresses, cc_addresses, subject,
+        body_markdown, body_plain, body_text, x_mailer, has_attachments,
+        attachments, folder, source, parent_id, content_hash, sender,
+        recipients, category_tags, project_tags, is_outbound
+    """
     
-    cursor.execute("""
-        SELECT * FROM emails 
+    cursor.execute(f"""
+        SELECT {conversation_columns}
+        FROM emails
         WHERE thread_id = ?
         ORDER BY timestamp ASC
     """, (thread_id,))
@@ -302,8 +311,9 @@ def get_conversation(thread_id: str) -> Optional[ConversationThread]:
     if not rows:
         if thread_id.startswith('thread-'):
             normalized_subject = thread_id.replace('thread-', '')
-            cursor.execute("""
-                SELECT * FROM emails 
+            cursor.execute(f"""
+                SELECT {conversation_columns}
+                FROM emails 
                 WHERE subject_thread_key = ?
                 ORDER BY timestamp ASC
             """, (normalized_subject,))

--- a/mcp_server/database.py
+++ b/mcp_server/database.py
@@ -87,14 +87,48 @@ def _decode_cursor(cursor: str) -> tuple:
 _thread_local = threading.local()
 
 _embedding_model = None
+_embedding_model_loading = False
+_embedding_model_load_error = None
+_embedding_model_lock = threading.Lock()
+
+
+def _load_embedding_model() -> None:
+    global _embedding_model, _embedding_model_loading, _embedding_model_load_error
+    try:
+        from sentence_transformers import SentenceTransformer
+        model = SentenceTransformer(Config.EMBEDDING_MODEL)
+        with _embedding_model_lock:
+            _embedding_model = model
+            _embedding_model_load_error = None
+    except Exception as exc:
+        with _embedding_model_lock:
+            _embedding_model_load_error = exc
+    finally:
+        with _embedding_model_lock:
+            _embedding_model_loading = False
+
+
+def initialize_embedding_model_async() -> None:
+    global _embedding_model_loading
+    with _embedding_model_lock:
+        if _embedding_model is not None or _embedding_model_loading:
+            return
+        _embedding_model_loading = True
+
+    thread = threading.Thread(target=_load_embedding_model, name="embedding-model-loader", daemon=True)
+    thread.start()
 
 
 def _get_embedding_model():
-    global _embedding_model
-    if _embedding_model is None:
-        from sentence_transformers import SentenceTransformer
-        _embedding_model = SentenceTransformer(Config.EMBEDDING_MODEL)
-    return _embedding_model
+    if _embedding_model is not None:
+        return _embedding_model
+
+    initialize_embedding_model_async()
+
+    if _embedding_model_load_error is not None:
+        raise RuntimeError(f"Embedding model failed to initialize: {_embedding_model_load_error}")
+
+    raise RuntimeError("Embedding model is still initializing. Retry semantic query shortly.")
 
 
 def _encode_text_to_embedding(text: str) -> bytes:
@@ -406,15 +440,19 @@ def query_email_database(
     conn = get_connection()
     cursor_conn = conn.cursor()
 
+    def _build_tag_filter_clause(column_name: str, tags: list[str]) -> str:
+        return " OR ".join([f"{column_name} LIKE ?" for _ in tags])
+
     where_clauses = []
     params = []
+    fts_query = None
 
     # Build WHERE clauses
     if exact_keywords:
         safe_query = exact_keywords.strip()
         if safe_query:
             where_clauses.append("emails_fts MATCH ?")
-            params.append(safe_query)
+            fts_query = safe_query
 
     if category_filter or project_filter:
         tags = []
@@ -423,10 +461,11 @@ def query_email_database(
         if project_filter:
             tags.extend([p.strip() for p in project_filter.split(",")])
         if tags:
-            tag_conditions = " OR ".join(["category_tags LIKE ?" for _ in tags])
-            tag_conditions += " OR " + " OR ".join(["project_tags LIKE ?" for _ in tags])
+            tag_conditions = _build_tag_filter_clause("e.category_tags", tags)
+            tag_conditions += " OR " + _build_tag_filter_clause("e.project_tags", tags)
             where_clauses.append(f"({tag_conditions})")
-            params.extend([f"%{t}%" for t in tags])
+            tag_params = [f"%{t}%" for t in tags]
+            params.extend(tag_params * 2)
 
     if date_from:
         where_clauses.append("e.timestamp >= ?")
@@ -463,10 +502,14 @@ def query_email_database(
             params.extend([last_ts, last_ts, last_id])
 
     where_sql = " AND ".join(where_clauses) if where_clauses else "1=1"
+    from_clause = "FROM emails e"
+    if exact_keywords:
+        from_clause += " JOIN emails_fts ON e.rowid = emails_fts.rowid"
+    query_params = ([fts_query] if fts_query else []) + list(params)
 
     # Handle count_only
     if count_only:
-        cursor_conn.execute(f"SELECT COUNT(*) as cnt FROM emails e WHERE {where_sql}", params)
+        cursor_conn.execute(f"SELECT COUNT(*) as cnt {from_clause} WHERE {where_sql}", query_params)
         count = cursor_conn.fetchone()["cnt"]
         close_connection()
         return {"count": count}
@@ -542,17 +585,16 @@ def query_email_database(
     if sort_by == "timestamp":
         order = "ASC" if sort_order == "asc" else "DESC"
         order_clause = f"ORDER BY e.timestamp {order}"
-        use_fts_join = False
     elif sort_by == "relevance":
         order = "ASC" if sort_order == "asc" else "DESC"
         if exact_keywords:
-            order_clause = f"ORDER BY fts.rank {order}"
+            order_clause = f"ORDER BY rank {order}"
         else:
             order_clause = f"ORDER BY e.timestamp {order}"
             use_fts_join = False
     else:
         if exact_keywords:
-            order_clause = "ORDER BY fts.rank DESC"
+            order_clause = "ORDER BY rank DESC"
         else:
             order_clause = "ORDER BY e.timestamp DESC"
             use_fts_join = False
@@ -563,15 +605,14 @@ def query_email_database(
     # Build SELECT columns
     if use_snippet:
         sql = f"""
-            SELECT e.id, e.thread_id, e.subject, e.timestamp, e.sender as from_address,
-                   e.from_name, e.has_attachments, e.folder,
-                   snippet(emails_fts, 1, '<mark>', '</mark>', '...', {snippet_length}) as snippet,
-                   bm25(emails_fts) as rank
-            FROM emails e
-            JOIN emails_fts fts ON e.rowid = fts.rowid
-            WHERE {where_sql}
-            {order_clause}
-            LIMIT ?
+                SELECT e.id, e.thread_id, e.subject, e.timestamp, e.sender as from_address,
+                       e.from_name, e.has_attachments, e.folder,
+                       snippet(emails_fts, 1, '<mark>', '</mark>', '...', {snippet_length}) as snippet,
+                       bm25(emails_fts) as rank
+                {from_clause}
+                WHERE {where_sql}
+                {order_clause}
+                LIMIT ?
         """
         use_fts_join = True
     elif fields is not None:
@@ -579,8 +620,7 @@ def query_email_database(
         if use_fts_join:
             sql = f"""
                 SELECT {columns}, bm25(emails_fts) as rank
-                FROM emails e
-                JOIN emails_fts fts ON e.rowid = fts.rowid
+                {from_clause}
                 WHERE {where_sql}
                 {order_clause}
                 LIMIT ?
@@ -599,8 +639,7 @@ def query_email_database(
                 SELECT e.id, e.thread_id, e.subject, e.timestamp, e.sender as from_address,
                        e.from_name, e.category_tags, e.project_tags, e.has_attachments, e.folder,
                        COALESCE(e.body_text, e.body_markdown) as body_text, bm25(emails_fts) as rank
-                FROM emails e
-                JOIN emails_fts fts ON e.rowid = fts.rowid
+                {from_clause}
                 WHERE {where_sql}
                 {order_clause}
                 LIMIT ?
@@ -615,9 +654,9 @@ def query_email_database(
                 {order_clause}
                 LIMIT ?
             """
-    params.append(limit)
+    final_params = query_params + [limit]
 
-    cursor_conn.execute(sql, params)
+    cursor_conn.execute(sql, final_params)
     results = cursor_conn.fetchall()
 
     # Compute normalized relevance scores for FTS5
@@ -840,8 +879,9 @@ def get_mention_timeline(
     conn = get_connection()
     cursor = conn.cursor()
 
-    where_clauses = ["e.rowid IN (SELECT rowid FROM emails_fts WHERE emails_fts MATCH ?)"]
-    params = [keyword]
+    from_clause = "FROM emails e JOIN emails_fts fts ON e.rowid = fts.rowid"
+    where_clauses = ["fts MATCH ?"]
+    params: list[object] = [keyword]
 
     if date_from:
         where_clauses.append("e.timestamp >= ?")
@@ -859,12 +899,12 @@ def get_mention_timeline(
     where_clauses.append("(e.source IS NULL OR e.source != 'quoted_reply')")
     where_sql = " AND ".join(where_clauses)
 
-    cursor.execute(f"SELECT COUNT(*) as cnt FROM emails e WHERE {where_sql}", params)
+    cursor.execute(f"SELECT COUNT(*) as cnt {from_clause} WHERE {where_sql}", params)
     total = cursor.fetchone()["cnt"]
 
     cursor.execute(f"""
         SELECT MIN(e.timestamp) as first, MAX(e.timestamp) as last
-        FROM emails e WHERE {where_sql}
+        {from_clause} WHERE {where_sql}
     """, params)
     bounds = cursor.fetchone()
 

--- a/mcp_server/database.py
+++ b/mcp_server/database.py
@@ -111,22 +111,24 @@ def _load_embedding_model() -> None:
 def initialize_embedding_model_async() -> None:
     global _embedding_model_loading
     with _embedding_model_lock:
-        if _embedding_model is not None or _embedding_model_loading:
+        if _embedding_model is not None or _embedding_model_loading or _embedding_model_load_error is not None:
             return
         _embedding_model_loading = True
-
-    thread = threading.Thread(target=_load_embedding_model, name="embedding-model-loader", daemon=True)
-    thread.start()
+        thread = threading.Thread(target=_load_embedding_model, name="embedding-model-loader", daemon=True)
+        thread.start()
 
 
 def _get_embedding_model():
-    if _embedding_model is not None:
-        return _embedding_model
-
-    initialize_embedding_model_async()
-
-    if _embedding_model_load_error is not None:
-        raise RuntimeError(f"Embedding model failed to initialize: {_embedding_model_load_error}")
+    global _embedding_model_loading
+    with _embedding_model_lock:
+        if _embedding_model is not None:
+            return _embedding_model
+        if _embedding_model_load_error is not None:
+            raise RuntimeError(f"Embedding model failed to initialize: {_embedding_model_load_error}")
+        if not _embedding_model_loading:
+            _embedding_model_loading = True
+            thread = threading.Thread(target=_load_embedding_model, name="embedding-model-loader", daemon=True)
+            thread.start()
 
     raise RuntimeError("Embedding model is still initializing. Retry semantic query shortly.")
 
@@ -919,7 +921,7 @@ def get_mention_timeline(
 
     cursor.execute(f"""
         SELECT {period_expr} as period, COUNT(*) as count
-        FROM emails e
+        {from_clause}
         WHERE {where_sql}
         GROUP BY period
         ORDER BY period

--- a/mcp_server/database.py
+++ b/mcp_server/database.py
@@ -439,6 +439,7 @@ def query_email_database(
     snippet_length: int = 32,
     cursor: Optional[str] = None,
 ) -> dict:
+    limit = max(1, min(limit, 50))
     conn = get_connection()
     cursor_conn = conn.cursor()
 
@@ -505,7 +506,7 @@ def query_email_database(
 
     where_sql = " AND ".join(where_clauses) if where_clauses else "1=1"
     from_clause = "FROM emails e"
-    if exact_keywords:
+    if fts_query:
         from_clause += " JOIN emails_fts ON e.rowid = emails_fts.rowid"
     query_params = ([fts_query] if fts_query else []) + list(params)
 
@@ -517,13 +518,13 @@ def query_email_database(
         return {"count": count}
 
     # Determine sort order
-    use_fts_join = bool(exact_keywords)
+    use_fts_join = bool(fts_query)
     
     # Determine if we need snippet (check before semantic query path)
-    use_snippet = snippet_only and (exact_keywords or semantic_query)
+    use_snippet = snippet_only and (bool(fts_query) or semantic_query)
     
     # Handle semantic query (vector search)
-    if semantic_query and not exact_keywords:
+    if semantic_query and not fts_query:
         try:
             query_embedding = _encode_text_to_embedding(semantic_query)
         except Exception as e:
@@ -541,10 +542,9 @@ def query_email_database(
             ORDER BY relevance_score ASC
             LIMIT ?
         """
-        params.insert(0, query_embedding)
-        params.append(limit)
+        semantic_params = [query_embedding, limit]
         
-        cursor_conn.execute(sql, params)
+        cursor_conn.execute(sql, semantic_params)
         results = cursor_conn.fetchall()
         
         output = []
@@ -589,20 +589,20 @@ def query_email_database(
         order_clause = f"ORDER BY e.timestamp {order}"
     elif sort_by == "relevance":
         order = "ASC" if sort_order == "asc" else "DESC"
-        if exact_keywords:
+        if fts_query:
             order_clause = f"ORDER BY rank {order}"
         else:
             order_clause = f"ORDER BY e.timestamp {order}"
             use_fts_join = False
     else:
-        if exact_keywords:
+        if fts_query:
             order_clause = "ORDER BY rank DESC"
         else:
             order_clause = "ORDER BY e.timestamp DESC"
             use_fts_join = False
 
     # Determine if we need snippet
-    use_snippet = snippet_only and (exact_keywords or semantic_query)
+    use_snippet = snippet_only and (bool(fts_query) or semantic_query)
 
     # Build SELECT columns
     if use_snippet:
@@ -663,7 +663,7 @@ def query_email_database(
 
     # Compute normalized relevance scores for FTS5
     rank_values = []
-    if exact_keywords:
+    if fts_query:
         raw_ranks = []
         for row in results:
             try:
@@ -881,8 +881,8 @@ def get_mention_timeline(
     conn = get_connection()
     cursor = conn.cursor()
 
-    from_clause = "FROM emails e JOIN emails_fts fts ON e.rowid = fts.rowid"
-    where_clauses = ["fts MATCH ?"]
+    from_clause = "FROM emails e JOIN emails_fts ON e.rowid = emails_fts.rowid"
+    where_clauses = ["emails_fts MATCH ?"]
     params: list[object] = [keyword]
 
     if date_from:

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -19,7 +19,8 @@ from .models import (
 from .database import (
     search_emails, get_email, get_conversation, find_recipient_emails,
     query_email_database, get_project_context, list_projects,
-    get_mention_timeline, get_contact_profile, get_thread_arc, list_threads
+    get_mention_timeline, get_contact_profile, get_thread_arc, list_threads,
+    initialize_embedding_model_async
 )
 from .config import Config
 
@@ -28,6 +29,7 @@ class MCPServer:
     def __init__(self):
         Config.ensure_directories()
         self._verify_schema()
+        initialize_embedding_model_async()
         self.tools = {
             "query_email_database": self.tool_query_email_database,
             "get_project_context": self.tool_get_project_context,

--- a/tests/test_blob_exclusion.py
+++ b/tests/test_blob_exclusion.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from mcp_server.database import get_email
+from mcp_server.database import get_email, get_conversation, close_connection
 from mcp_server.config import Config
 
 def create_test_db():
@@ -39,18 +39,25 @@ def create_test_db():
     conn.close()
     return path
 
+
+def update_test_blobs(path: str):
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "UPDATE emails SET raw_eml = X'DEADBEEF', embedding = X'01020304' WHERE id = '550e8400-e29b-41d4-a716-446655440000'"
+    )
+    conn.commit()
+    conn.close()
+
 def test_get_email_excludes_raw_eml():
     path = create_test_db()
+    original_db = Config.DB_PATH
     try:
-        conn = sqlite3.connect(path)
-        conn.execute("UPDATE emails SET raw_eml = X'DEADBEEF' WHERE id = '550e8400-e29b-41d4-a716-446655440000'")
-        conn.commit()
-        conn.close()
+        update_test_blobs(path)
 
-        original_db = Config.DB_PATH
         Config.DB_PATH = Path(path)
 
         result = get_email("550e8400-e29b-41d4-a716-446655440000")
+        assert result is not None
         assert result.raw_eml is None, f"raw_eml should be None, got {type(result.raw_eml)}"
         print("✓ test_get_email_excludes_raw_eml passed")
     finally:
@@ -59,11 +66,12 @@ def test_get_email_excludes_raw_eml():
 
 def test_get_email_excludes_embedding():
     path = create_test_db()
+    original_db = Config.DB_PATH
     try:
-        original_db = Config.DB_PATH
         Config.DB_PATH = Path(path)
 
         result = get_email("550e8400-e29b-41d4-a716-446655440000")
+        assert result is not None
         dumped = result.model_dump(mode='json')
         assert "embedding" not in dumped, f"embedding should not be in response, got keys: {dumped.keys()}"
         print("✓ test_get_email_excludes_embedding passed")
@@ -71,7 +79,63 @@ def test_get_email_excludes_embedding():
         Config.DB_PATH = original_db
         os.unlink(path)
 
+def test_get_conversation_fallback_excludes_blob_fields():
+    path = create_test_db()
+    original_db = Config.DB_PATH
+    try:
+        update_test_blobs(path)
+
+        Config.DB_PATH = Path(path)
+
+        result = get_conversation("thread-test")
+        assert result is not None
+        dumped = result.model_dump(mode='json')
+
+        assert dumped["emails"][0]["raw_eml"] is None, (
+            f"raw_eml should be None in fallback conversation path, got {type(dumped['emails'][0]['raw_eml'])}"
+        )
+        assert "embedding" not in dumped["emails"][0], (
+            f"embedding should not be in fallback conversation response, got keys: {dumped['emails'][0].keys()}"
+        )
+    finally:
+        close_connection()
+        Config.DB_PATH = original_db
+        os.unlink(path)
+
+
+def test_get_conversation_primary_thread_path_excludes_blob_fields():
+    path = create_test_db()
+    original_db = Config.DB_PATH
+    try:
+        update_test_blobs(path)
+
+        conn = sqlite3.connect(path)
+        conn.execute(
+            "UPDATE emails SET thread_id = 'thread-real' WHERE id = '550e8400-e29b-41d4-a716-446655440000'"
+        )
+        conn.commit()
+        conn.close()
+
+        Config.DB_PATH = Path(path)
+
+        result = get_conversation("thread-real")
+        assert result is not None
+        dumped = result.model_dump(mode='json')
+
+        assert dumped["emails"][0]["raw_eml"] is None, (
+            f"raw_eml should be None in primary thread path, got {type(dumped['emails'][0]['raw_eml'])}"
+        )
+        assert "embedding" not in dumped["emails"][0], (
+            f"embedding should not be in primary thread response, got keys: {dumped['emails'][0].keys()}"
+        )
+    finally:
+        close_connection()
+        Config.DB_PATH = original_db
+        os.unlink(path)
+
 if __name__ == "__main__":
     test_get_email_excludes_raw_eml()
     test_get_email_excludes_embedding()
+    test_get_conversation_fallback_excludes_blob_fields()
+    test_get_conversation_primary_thread_path_excludes_blob_fields()
     print("\n✅ All blob exclusion tests passed!")

--- a/tests/test_blob_exclusion.py
+++ b/tests/test_blob_exclusion.py
@@ -61,6 +61,7 @@ def test_get_email_excludes_raw_eml():
         assert result.raw_eml is None, f"raw_eml should be None, got {type(result.raw_eml)}"
         print("✓ test_get_email_excludes_raw_eml passed")
     finally:
+        close_connection()
         Config.DB_PATH = original_db
         os.unlink(path)
 
@@ -68,6 +69,7 @@ def test_get_email_excludes_embedding():
     path = create_test_db()
     original_db = Config.DB_PATH
     try:
+        update_test_blobs(path)
         Config.DB_PATH = Path(path)
 
         result = get_email("550e8400-e29b-41d4-a716-446655440000")
@@ -76,6 +78,7 @@ def test_get_email_excludes_embedding():
         assert "embedding" not in dumped, f"embedding should not be in response, got keys: {dumped.keys()}"
         print("✓ test_get_email_excludes_embedding passed")
     finally:
+        close_connection()
         Config.DB_PATH = original_db
         os.unlink(path)
 

--- a/tests/test_mention_timeline.py
+++ b/tests/test_mention_timeline.py
@@ -73,7 +73,21 @@ def test_timeline_with_filters():
     finally:
         os.unlink(path)
 
+
+def test_timeline_uses_fts_table_name_in_match_clause():
+    path = create_test_db()
+    try:
+        Config.DB_PATH = Path(path)
+        result = get_mention_timeline(keyword="John Doe", granularity="month")
+        assert result["total_matches"] > 0, f"Expected timeline matches, got {result}"
+        assert any(period.startswith("2015-") for period in result["timeline"].keys()), (
+            f"Expected month-granularity timeline periods, got {result['timeline']}"
+        )
+    finally:
+        os.unlink(path)
+
 if __name__ == "__main__":
     test_timeline_yearly()
     test_timeline_with_filters()
+    test_timeline_uses_fts_table_name_in_match_clause()
     print("\n✅ All mention timeline tests passed!")

--- a/tests/test_mention_timeline.py
+++ b/tests/test_mention_timeline.py
@@ -31,15 +31,16 @@ def create_test_db():
         for i in range(year - 2014):
             uid = f"550e8400-{year:04d}-{i:04d}-0000-000000000000"
             ts = f"{year}-06-15T10:00:00Z"
+            body_markdown = f"John Doe mentioned in {year} ftsonlytoken{year}{i}"
             cursor.execute("""
                 INSERT INTO emails (id, message_id, timestamp, from_address, from_name,
                     to_addresses, subject, body_markdown, body_text, folder, sender, recipients,
                     subject_thread_key)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """, (uid, f"<{year}-{i}@example.com>", ts, "alice@example.com", "Alice",
-                  '["me@example.com"]', f"Mention {year}-{i}", f"John Doe mentioned in {year}",
+                  '["me@example.com"]', f"Mention {year}-{i}", body_markdown,
                   f"John Doe {year}", "INBOX", "alice@example.com", '["me@example.com"]', f"mention {year}"))
-            cursor.execute("INSERT INTO emails_fts(rowid, subject, body_markdown) VALUES (last_insert_rowid(), ?, ?)", (f"Mention {year}", f"John Doe {year}"))
+            cursor.execute("INSERT INTO emails_fts(rowid, subject, body_markdown) VALUES (last_insert_rowid(), ?, ?)", (f"Mention {year}", body_markdown))
 
     conn.commit()
     conn.close()
@@ -78,7 +79,7 @@ def test_timeline_uses_fts_table_name_in_match_clause():
     path = create_test_db()
     try:
         Config.DB_PATH = Path(path)
-        result = get_mention_timeline(keyword="John Doe", granularity="month")
+        result = get_mention_timeline(keyword="ftsonlytoken20150", granularity="month")
         assert result["total_matches"] > 0, f"Expected timeline matches, got {result}"
         assert any(period.startswith("2015-") for period in result["timeline"].keys()), (
             f"Expected month-granularity timeline periods, got {result['timeline']}"

--- a/tests/test_query_extensions.py
+++ b/tests/test_query_extensions.py
@@ -140,6 +140,63 @@ def test_semantic_query_returns_timeout_error_without_loading_model():
     assert "Failed to encode semantic query" in result["error"], f"Expected semantic error, got {result}"
 
 
+def test_semantic_query_with_filters_does_not_reuse_fts_params():
+    class FakeCursor:
+        def __init__(self):
+            self.calls = []
+
+        def execute(self, sql, params):
+            self.calls.append((sql, params))
+
+        def fetchall(self):
+            return []
+
+    class FakeConnection:
+        def __init__(self, cursor):
+            self._cursor = cursor
+
+        def cursor(self):
+            return self._cursor
+
+    fake_cursor = FakeCursor()
+    fake_conn = FakeConnection(fake_cursor)
+
+    with patch("mcp_server.database._encode_text_to_embedding", return_value=b"fake-embedding"), \
+         patch("mcp_server.database.get_connection", return_value=fake_conn), \
+         patch("mcp_server.database.close_connection"):
+        result = query_email_database(semantic_query="project update", category_filter="finance")
+
+    assert result["results"] == [], f"Expected empty semantic result set from fake cursor, got {result}"
+    assert len(fake_cursor.calls) == 1, f"Expected exactly one semantic query execution, got {fake_cursor.calls}"
+    _, params = fake_cursor.calls[0]
+    assert params == [b"fake-embedding", 10], f"Expected semantic params to exclude filter placeholders, got {params}"
+
+
+def test_whitespace_keywords_do_not_enable_fts_join():
+    path = create_test_db()
+    original_db = Config.DB_PATH
+    try:
+        Config.DB_PATH = Path(path)
+        result = query_email_database(exact_keywords="   ", sort_by="timestamp", limit=2)
+        assert len(result["results"]) == 2, f"Expected normal non-FTS query results, got {result}"
+    finally:
+        Config.DB_PATH = original_db
+        os.unlink(path)
+
+
+def test_limit_is_clamped_to_documented_maximum():
+    path = create_test_db()
+    original_db = Config.DB_PATH
+    try:
+        Config.DB_PATH = Path(path)
+        result = query_email_database(limit=999)
+        assert len(result["results"]) == 4, f"Expected existing rows only after clamp, got {len(result['results'])}"
+        assert result["has_more"] is False, f"Expected has_more false for clamped limit, got {result}"
+    finally:
+        Config.DB_PATH = original_db
+        os.unlink(path)
+
+
 def test_get_embedding_model_returns_initializing_error_without_blocking():
     with patch("mcp_server.database.threading.Thread") as thread_mock, \
          patch("mcp_server.database._embedding_model", None), \
@@ -161,5 +218,8 @@ if __name__ == "__main__":
     test_tag_filters_bind_all_placeholders()
     test_fts_snippet_query_uses_join_alias()
     test_semantic_query_returns_timeout_error_without_loading_model()
+    test_semantic_query_with_filters_does_not_reuse_fts_params()
+    test_whitespace_keywords_do_not_enable_fts_join()
+    test_limit_is_clamped_to_documented_maximum()
     test_get_embedding_model_returns_initializing_error_without_blocking()
     print("\n✅ All query extension tests passed!")

--- a/tests/test_query_extensions.py
+++ b/tests/test_query_extensions.py
@@ -1,9 +1,10 @@
 import sys, tempfile, sqlite3, os
 from pathlib import Path
+from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from mcp_server.database import query_email_database
+from mcp_server.database import query_email_database, _get_embedding_model
 from mcp_server.config import Config
 
 def create_test_db():
@@ -106,10 +107,57 @@ def test_relevance_score_in_fts_results():
     finally:
         os.unlink(path)
 
+
+def test_tag_filters_bind_all_placeholders():
+    path = create_test_db()
+    original_db = Config.DB_PATH
+    try:
+        Config.DB_PATH = Path(path)
+        result = query_email_database(category_filter="finance,work", project_filter="alpha")
+        assert "results" in result, f"Expected results key, got {result.keys()}"
+    finally:
+        Config.DB_PATH = original_db
+        os.unlink(path)
+
+
+def test_fts_snippet_query_uses_join_alias():
+    path = create_test_db()
+    original_db = Config.DB_PATH
+    try:
+        Config.DB_PATH = Path(path)
+        result = query_email_database(exact_keywords="John Doe", snippet_only=True, limit=2)
+        assert len(result["results"]) >= 1, f"Expected snippet results, got {result}"
+        assert "snippet" in result["results"][0], f"Expected snippet field, got {result['results'][0].keys()}"
+    finally:
+        Config.DB_PATH = original_db
+        os.unlink(path)
+
+
+def test_semantic_query_returns_timeout_error_without_loading_model():
+    with patch("mcp_server.database._encode_text_to_embedding", side_effect=TimeoutError("model init timed out")):
+        result = query_email_database(semantic_query="project update")
+    assert result["results"] == [], f"Expected empty results on semantic timeout, got {result}"
+    assert "Failed to encode semantic query" in result["error"], f"Expected semantic error, got {result}"
+
+
+def test_get_embedding_model_returns_initializing_error_without_blocking():
+    with patch("mcp_server.database.initialize_embedding_model_async") as init_mock, \
+         patch("mcp_server.database._embedding_model", None), \
+         patch("mcp_server.database._embedding_model_load_error", None):
+        try:
+            _get_embedding_model()
+            assert False, "Expected initialization-in-progress error"
+        except RuntimeError as exc:
+            assert "still initializing" in str(exc), f"Unexpected error: {exc}"
+        init_mock.assert_called_once()
+
 if __name__ == "__main__":
     test_count_only_returns_count()
     test_sort_by_timestamp_asc()
     test_sort_by_timestamp_desc()
     test_from_name_filter()
     test_relevance_score_in_fts_results()
+    test_tag_filters_bind_all_placeholders()
+    test_fts_snippet_query_uses_join_alias()
+    test_semantic_query_returns_timeout_error_without_loading_model()
     print("\n✅ All query extension tests passed!")

--- a/tests/test_query_extensions.py
+++ b/tests/test_query_extensions.py
@@ -195,7 +195,10 @@ def test_semantic_query_with_filters_applies_shared_where_clause():
     assert result["results"] == [], f"Expected empty semantic result set from fake cursor, got {result}"
     assert len(fake_cursor.calls) == 1, f"Expected exactly one semantic query execution, got {fake_cursor.calls}"
     sql, params = fake_cursor.calls[0]
-    assert "category_tags" in sql and "project_tags" in sql, f"Expected semantic SQL to reuse filter WHERE clauses, got {sql}"
+    assert "category_tags" in sql, f'Expected "category_tags" in SQL, got {sql}'
+    assert "project_tags" in sql, f'Expected "project_tags" in SQL, got {sql}'
+    # Tags appear twice because the shared WHERE clause binds the same tag list
+    # once for category_tags and once again for project_tags.
     assert params == [b"fake-embedding", "%finance%", "%alpha%", "%finance%", "%alpha%", 10], (
         f"Expected semantic params to include shared filter placeholders, got {params}"
     )

--- a/tests/test_query_extensions.py
+++ b/tests/test_query_extensions.py
@@ -141,15 +141,16 @@ def test_semantic_query_returns_timeout_error_without_loading_model():
 
 
 def test_get_embedding_model_returns_initializing_error_without_blocking():
-    with patch("mcp_server.database.initialize_embedding_model_async") as init_mock, \
+    with patch("mcp_server.database.threading.Thread") as thread_mock, \
          patch("mcp_server.database._embedding_model", None), \
-         patch("mcp_server.database._embedding_model_load_error", None):
+         patch("mcp_server.database._embedding_model_load_error", None), \
+         patch("mcp_server.database._embedding_model_loading", False):
         try:
             _get_embedding_model()
             assert False, "Expected initialization-in-progress error"
         except RuntimeError as exc:
             assert "still initializing" in str(exc), f"Unexpected error: {exc}"
-        init_mock.assert_called_once()
+        thread_mock.assert_called_once()
 
 if __name__ == "__main__":
     test_count_only_returns_count()
@@ -160,4 +161,5 @@ if __name__ == "__main__":
     test_tag_filters_bind_all_placeholders()
     test_fts_snippet_query_uses_join_alias()
     test_semantic_query_returns_timeout_error_without_loading_model()
+    test_get_embedding_model_returns_initializing_error_without_blocking()
     print("\n✅ All query extension tests passed!")

--- a/tests/test_query_extensions.py
+++ b/tests/test_query_extensions.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from mcp_server.database import query_email_database, _get_embedding_model
+from mcp_server.database import query_email_database, _get_embedding_model, initialize_embedding_model_async
 from mcp_server.config import Config
 
 def create_test_db():
@@ -29,20 +29,31 @@ def create_test_db():
     cursor.execute("CREATE VIRTUAL TABLE emails_fts USING fts5(subject, body_markdown, content=emails, content_rowid=rowid)")
 
     emails = [
-        ("001", "2013-01-01T10:00:00Z", "john@old.com", "John Doe", "john@old.com", '["me@example.com"]', "Old mention of John", "John Doe discussed the project."),
-        ("002", "2016-06-15T14:00:00Z", "john@mid.com", "John Doe", "john@mid.com", '["me@example.com"]', "Mid-era John email", "Meeting with John Doe went well."),
-        ("003", "2020-03-20T09:00:00Z", "john@new.com", "J. Doe", "john@new.com", '["me@example.com"]', "Recent John", "John Doe approved the budget."),
-        ("004", "2022-12-01T16:00:00Z", "alice@corp.com", "Alice Smith", "alice@corp.com", '["me@example.com"]', "Alice email", "No John here, just Alice."),
+        ("001", "2013-01-01T10:00:00Z", "john@old.com", "John Doe", "john@old.com", '["me@example.com"]', "Old mention of John", "John Doe discussed the project.", "[]", "[]"),
+        ("002", "2016-06-15T14:00:00Z", "john@mid.com", "John Doe", "john@mid.com", '["me@example.com"]', "Mid-era John email", "Meeting with John Doe went well.", "[]", "[]"),
+        ("003", "2020-03-20T09:00:00Z", "john@new.com", "J. Doe", "john@new.com", '["me@example.com"]', "Recent John", "John Doe approved the budget.", "[]", "[]"),
+        ("004", "2022-12-01T16:00:00Z", "alice@corp.com", "Alice Smith", "alice@corp.com", '["me@example.com"]', "Alice email", "No John here, just Alice.", "[]", "[]"),
+        ("005", "2021-04-10T11:30:00Z", "finance@corp.com", "Finance Bot", "finance@corp.com", '["me@example.com"]', "Budget update", "Project Alpha finance update.", '["finance"]', '["alpha"]'),
     ]
-    for eid, ts, sender, name, sender2, recip, subj, body in emails:
+    for eid, ts, sender, name, sender2, recip, subj, body, category_tags, project_tags in emails:
         uid = f"550e8400-0000-0000-0000-000000000{eid}"
         cursor.execute("""
             INSERT INTO emails (id, message_id, timestamp, from_address, from_name,
                 to_addresses, subject, body_markdown, body_text, folder, sender, recipients,
                 category_tags, project_tags, is_outbound, subject_thread_key)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        """, (uid, f"<{eid}@example.com>", ts, sender, name, recip, subj, body, body, "INBOX", sender2, recip, "[]", "[]", 0, subj.lower()))
+        """, (uid, f"<{eid}@example.com>", ts, sender, name, recip, subj, body, body, "INBOX", sender2, recip, category_tags, project_tags, 0, subj.lower()))
         cursor.execute("INSERT INTO emails_fts(rowid, subject, body_markdown) VALUES (last_insert_rowid(), ?, ?)", (subj, body))
+
+    cursor.execute("""
+        CREATE TABLE email_vectors (
+            email_id TEXT PRIMARY KEY,
+            embedding BLOB
+        )
+    """)
+    for eid in ["001", "002", "003", "004", "005"]:
+        uid = f"550e8400-0000-0000-0000-000000000{eid}"
+        cursor.execute("INSERT INTO email_vectors(email_id, embedding) VALUES (?, ?)", (uid, b"fake-vector"))
 
     conn.commit()
     conn.close()
@@ -134,13 +145,23 @@ def test_fts_snippet_query_uses_join_alias():
 
 
 def test_semantic_query_returns_timeout_error_without_loading_model():
-    with patch("mcp_server.database._encode_text_to_embedding", side_effect=TimeoutError("model init timed out")):
+    class FakeCursor:
+        def execute(self, sql, params):
+            raise AssertionError("Query should not execute when embedding encoding fails")
+
+    class FakeConnection:
+        def cursor(self):
+            return FakeCursor()
+
+    with patch("mcp_server.database.get_connection", return_value=FakeConnection()), \
+         patch("mcp_server.database.close_connection"), \
+         patch("mcp_server.database._encode_text_to_embedding", side_effect=TimeoutError("model init timed out")):
         result = query_email_database(semantic_query="project update")
     assert result["results"] == [], f"Expected empty results on semantic timeout, got {result}"
     assert "Failed to encode semantic query" in result["error"], f"Expected semantic error, got {result}"
 
 
-def test_semantic_query_with_filters_does_not_reuse_fts_params():
+def test_semantic_query_with_filters_applies_shared_where_clause():
     class FakeCursor:
         def __init__(self):
             self.calls = []
@@ -164,12 +185,20 @@ def test_semantic_query_with_filters_does_not_reuse_fts_params():
     with patch("mcp_server.database._encode_text_to_embedding", return_value=b"fake-embedding"), \
          patch("mcp_server.database.get_connection", return_value=fake_conn), \
          patch("mcp_server.database.close_connection"):
-        result = query_email_database(semantic_query="project update", category_filter="finance")
+        result = query_email_database(
+            semantic_query="project update",
+            category_filter="finance",
+            project_filter="alpha",
+            limit=10,
+        )
 
     assert result["results"] == [], f"Expected empty semantic result set from fake cursor, got {result}"
     assert len(fake_cursor.calls) == 1, f"Expected exactly one semantic query execution, got {fake_cursor.calls}"
-    _, params = fake_cursor.calls[0]
-    assert params == [b"fake-embedding", 10], f"Expected semantic params to exclude filter placeholders, got {params}"
+    sql, params = fake_cursor.calls[0]
+    assert "category_tags" in sql and "project_tags" in sql, f"Expected semantic SQL to reuse filter WHERE clauses, got {sql}"
+    assert params == [b"fake-embedding", "%finance%", "%alpha%", "%finance%", "%alpha%", 10], (
+        f"Expected semantic params to include shared filter placeholders, got {params}"
+    )
 
 
 def test_whitespace_keywords_do_not_enable_fts_join():
@@ -190,7 +219,7 @@ def test_limit_is_clamped_to_documented_maximum():
     try:
         Config.DB_PATH = Path(path)
         result = query_email_database(limit=999)
-        assert len(result["results"]) == 4, f"Expected existing rows only after clamp, got {len(result['results'])}"
+        assert len(result["results"]) == 5, f"Expected existing rows only after clamp, got {len(result['results'])}"
         assert result["has_more"] is False, f"Expected has_more false for clamped limit, got {result}"
     finally:
         Config.DB_PATH = original_db
@@ -209,6 +238,16 @@ def test_get_embedding_model_returns_initializing_error_without_blocking():
             assert "still initializing" in str(exc), f"Unexpected error: {exc}"
         thread_mock.assert_called_once()
 
+
+def test_initialize_embedding_model_async_retries_after_previous_failure():
+    with patch("mcp_server.database.threading.Thread") as thread_mock, \
+         patch("mcp_server.database._embedding_model", None), \
+         patch("mcp_server.database._embedding_model_loading", False), \
+         patch("mcp_server.database._embedding_model_load_error", RuntimeError("temporary failure")):
+        initialize_embedding_model_async()
+
+        thread_mock.assert_called_once()
+
 if __name__ == "__main__":
     test_count_only_returns_count()
     test_sort_by_timestamp_asc()
@@ -218,8 +257,9 @@ if __name__ == "__main__":
     test_tag_filters_bind_all_placeholders()
     test_fts_snippet_query_uses_join_alias()
     test_semantic_query_returns_timeout_error_without_loading_model()
-    test_semantic_query_with_filters_does_not_reuse_fts_params()
+    test_semantic_query_with_filters_applies_shared_where_clause()
     test_whitespace_keywords_do_not_enable_fts_join()
     test_limit_is_clamped_to_documented_maximum()
     test_get_embedding_model_returns_initializing_error_without_blocking()
+    test_initialize_embedding_model_async_retries_after_previous_failure()
     print("\n✅ All query extension tests passed!")


### PR DESCRIPTION
## **User description**
## Summary
- fix FTS-backed `query_email_database` filtering by binding the right tag parameters and using consistent `emails_fts` references for count, snippet, and ranking queries
- replace conversation `SELECT *` lookups with explicit non-BLOB columns for both primary and fallback thread retrieval paths
- start embedding model initialization at server startup and fail semantic queries fast with a retryable error instead of timing out in-request

## Testing
- `/Users/thomasmaerz/emailindex/.venv/bin/python -m pytest tests/test_blob_exclusion.py tests/test_query_extensions.py -q`
- `mkdir -p ingestion/logs && /Users/thomasmaerz/emailindex/.venv/bin/python -m pytest tests/ -x -q` *(stops on pre-existing unrelated failure: `tests/test_classify_pagination.py::TestClassifyEmailsPagination::test_checkpoint_backward_compat_fresh`, also failing on clean main)*

Closes #31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Embedding model now initializes asynchronously during server startup and surfaces initialization failures without blocking.

* **Improvements**
  * More consistent search/query behavior: FTS matching, relevance ordering, snippet generation, tag/category filtering, semantic-query handling, and limit clamping improved.
  * Conversation and email responses reliably exclude large/raw blob fields.

* **Tests**
  * Added and extended tests covering blob exclusion, FTS/snippet behavior, tag binding, limits, semantic-query timeouts, embedding-init states, and timeline aggregation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Fix conversation, search, and semantic query failures in email tools**

### What Changed
- Conversation views now load without returning large binary fields, in both normal thread lookups and fallback thread matching
- Email search now handles tag filters and full-text snippets correctly, and keyword searches use the proper search path for counts and ranking
- Semantic search starts model loading in the background and returns a clear retry message instead of hanging when the model is not ready
- Mention timeline queries now use the same search path as other keyword lookups so matching results and counts stay consistent
- Added coverage for blob exclusion, tag filtering, snippet search, and semantic model startup behavior

### Impact
`✅ Fewer broken conversation views`
`✅ Faster email search responses`
`✅ Clearer semantic query retry errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
