### PR TITLE
fix: default HF_HUB_OFFLINE=1 at MCP server startup to prevent embedding hang (#32)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,8 +35,8 @@ The Email Intelligence System parses personal email archives into a queryable SQ
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `HF_HUB_OFFLINE` | `1` | Set to `1` (default) to use cached model only and avoid HuggingFace Hub network checks. Set to `0` to allow model update checks (requires internet + optional `HF_TOKEN`). |
-| `HF_TOKEN` | — | Optional HuggingFace token for authenticated Hub access when `HF_HUB_OFFLINE=0`. |
+| `HF_HUB_OFFLINE` | `1` | Set to `1` (default) to use cached model only and avoid HuggingFace Hub network checks. Set to `0` to allow model update checks (requires internet + optional `HF_TOKEN`). When `HF_HUB_OFFLINE=0`, unauthenticated Hub checks can hit rate limits and may cause first-query hangs/timeouts. |
+| `HF_TOKEN` | — | Optional HuggingFace token for authenticated Hub access when `HF_HUB_OFFLINE=0`. Set this for online mode to avoid unauthenticated rate-limit stalls. |
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,13 @@ The Email Intelligence System parses personal email archives into a queryable SQ
 - **Attachment management** with SHA-256 deduplication
 - **Parallel resumable ingestion** for large archives (12+ years of email) using ThreadPoolExecutor with configurable concurrency
 
+## Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `HF_HUB_OFFLINE` | `1` | Set to `1` (default) to use cached model only and avoid HuggingFace Hub network checks. Set to `0` to allow model update checks (requires internet + optional `HF_TOKEN`). |
+| `HF_TOKEN` | — | Optional HuggingFace token for authenticated Hub access when `HF_HUB_OFFLINE=0`. |
+
 ---
 
 ## 2. Directory Structure

--- a/run-mcp-server.py
+++ b/run-mcp-server.py
@@ -4,6 +4,8 @@ import os
 import time
 import json
 
+os.environ.setdefault("HF_HUB_OFFLINE", "1")
+
 with open('/tmp/mcp_start.log', 'a') as f:
     f.write(f'START at {time.time()}\n')
     f.write(f'argv: {sys.argv}\n')

--- a/run-mcp-server.sh
+++ b/run-mcp-server.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 # Wrapper script to run MCP server - avoids conda init overhead
 export PYTHONPATH="/Users/thomasmaerz/emailindex"
+export HF_HUB_OFFLINE="${HF_HUB_OFFLINE:-1}"
 exec /Users/thomasmaerz/miniconda3/envs/emailindex/bin/python3 -m mcp_server.server --stdio

--- a/tests/test_embedding_offline.py
+++ b/tests/test_embedding_offline.py
@@ -1,0 +1,52 @@
+import os
+import sys
+import builtins
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+def test_run_mcp_server_sets_hf_hub_offline_before_server_import():
+    script_path = Path(__file__).parent.parent / "run-mcp-server.py"
+    script_code = script_path.read_text()
+
+    fake_globals = {
+        "__name__": "__main__",
+        "__file__": str(script_path),
+    }
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "mcp_server.server":
+            assert os.environ.get("HF_HUB_OFFLINE") == "1", os.environ.get("HF_HUB_OFFLINE")
+
+            class DummyServer:
+                def __init__(self):
+                    pass
+
+                def handle_request(self, request):
+                    return None
+
+            return type("FakeModule", (), {"MCPServer": DummyServer})
+        return real_import(name, globals, locals, fromlist, level)
+
+    original_argv = list(sys.argv)
+    original_pythonpath = os.environ.get("PYTHONPATH")
+    original_hf = os.environ.get("HF_HUB_OFFLINE")
+
+    try:
+        os.environ.pop("HF_HUB_OFFLINE", None)
+        with patch("builtins.__import__", side_effect=fake_import), \
+             patch("sys.stdin", []):
+            exec(compile(script_code, str(script_path), "exec"), fake_globals)
+    finally:
+        sys.argv[:] = original_argv
+        if original_pythonpath is None:
+            os.environ.pop("PYTHONPATH", None)
+        else:
+            os.environ["PYTHONPATH"] = original_pythonpath
+        if original_hf is None:
+            os.environ.pop("HF_HUB_OFFLINE", None)
+        else:
+            os.environ["HF_HUB_OFFLINE"] = original_hf

--- a/tests/test_embedding_offline.py
+++ b/tests/test_embedding_offline.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import builtins
+import importlib.util
 from pathlib import Path
 from unittest.mock import patch
 
@@ -9,15 +10,9 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 def test_run_mcp_server_sets_hf_hub_offline_before_server_import():
     script_path = Path(__file__).parent.parent / "run-mcp-server.py"
-    script_code = script_path.read_text()
-
-    fake_globals = {
-        "__name__": "__main__",
-        "__file__": str(script_path),
-    }
     real_import = builtins.__import__
 
-    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+    def fake_import(name, globs=None, locs=None, fromlist=(), level=0):
         if name == "mcp_server.server":
             assert os.environ.get("HF_HUB_OFFLINE") == "1", os.environ.get("HF_HUB_OFFLINE")
 
@@ -29,7 +24,7 @@ def test_run_mcp_server_sets_hf_hub_offline_before_server_import():
                     return None
 
             return type("FakeModule", (), {"MCPServer": DummyServer})
-        return real_import(name, globals, locals, fromlist, level)
+        return real_import(name, globs, locs, fromlist, level)
 
     original_argv = list(sys.argv)
     original_pythonpath = os.environ.get("PYTHONPATH")
@@ -37,9 +32,12 @@ def test_run_mcp_server_sets_hf_hub_offline_before_server_import():
 
     try:
         os.environ.pop("HF_HUB_OFFLINE", None)
+        spec = importlib.util.spec_from_file_location("run_mcp_server_test_module", script_path)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
         with patch("builtins.__import__", side_effect=fake_import), \
              patch("sys.stdin", []):
-            exec(compile(script_code, str(script_path), "exec"), fake_globals)
+            spec.loader.exec_module(module)
     finally:
         sys.argv[:] = original_argv
         if original_pythonpath is None:


### PR DESCRIPTION
## **User description**
## What
- Default `HF_HUB_OFFLINE=1` in both MCP server startup entrypoints before model-related imports
- Document `HF_HUB_OFFLINE` and optional `HF_TOKEN` configuration in `AGENTS.md`
- Add a regression test verifying the Python entrypoint sets offline mode before importing the MCP server

## Why
The first semantic query could hang while `sentence-transformers` triggered HuggingFace Hub network checks. Defaulting to offline mode keeps startup and first-query model access on cached artifacts unless the caller explicitly opts into online refresh behavior.

## Testing
- `/Users/thomasmaerz/emailindex/.venv/bin/python -m pytest tests/test_embedding_offline.py -q`
- `/Users/thomasmaerz/emailindex/.venv/bin/python -m pytest tests/test_query_extensions.py -q`

Closes #32


___

## **CodeAnt-AI Description**
**Start the MCP server in offline mode by default to avoid startup hangs**

### What Changed
- The MCP server now starts with HuggingFace Hub offline mode enabled unless it is already set
- The shell wrapper also defaults to offline mode, so model loading uses cached files instead of waiting on network checks
- Added a regression test to confirm offline mode is set before the server is imported
- Documented the offline setting and optional HuggingFace token for online access

### Impact
`✅ Fewer startup hangs`
`✅ Faster first query after launch`
`✅ Clearer HuggingFace configuration`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled Hugging Face offline mode by default to avoid unnecessary hub network checks.

* **Documentation**
  * Added a configuration section documenting environment variables for offline mode and optional token usage.

* **Tests**
  * Added automated test ensuring offline mode is set before the server loads to prevent runtime network checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->