### PR TITLE
test: cover semantic query metadata filters (#33)

### DIFF
--- a/tests/test_query_extensions.py
+++ b/tests/test_query_extensions.py
@@ -7,6 +7,29 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from mcp_server.database import query_email_database, _get_embedding_model, initialize_embedding_model_async
 from mcp_server.config import Config
 
+
+def create_fake_db_connection():
+    class FakeCursor:
+        def __init__(self):
+            self.calls = []
+
+        def execute(self, sql, params):
+            self.calls.append((sql, params))
+
+        def fetchall(self):
+            return []
+
+    class FakeConnection:
+        def __init__(self, cursor):
+            self._cursor = cursor
+
+        def cursor(self):
+            return self._cursor
+
+    fake_cursor = FakeCursor()
+    fake_conn = FakeConnection(fake_cursor)
+    return fake_conn, fake_cursor
+
 def create_test_db():
     fd, path = tempfile.mkstemp(suffix='.db')
     os.close(fd)
@@ -162,25 +185,7 @@ def test_semantic_query_returns_timeout_error_without_loading_model():
 
 
 def test_semantic_query_with_filters_applies_shared_where_clause():
-    class FakeCursor:
-        def __init__(self):
-            self.calls = []
-
-        def execute(self, sql, params):
-            self.calls.append((sql, params))
-
-        def fetchall(self):
-            return []
-
-    class FakeConnection:
-        def __init__(self, cursor):
-            self._cursor = cursor
-
-        def cursor(self):
-            return self._cursor
-
-    fake_cursor = FakeCursor()
-    fake_conn = FakeConnection(fake_cursor)
+    fake_conn, fake_cursor = create_fake_db_connection()
 
     with patch("mcp_server.database._encode_text_to_embedding", return_value=b"fake-embedding"), \
          patch("mcp_server.database.get_connection", return_value=fake_conn), \
@@ -205,25 +210,7 @@ def test_semantic_query_with_filters_applies_shared_where_clause():
 
 
 def test_semantic_query_with_date_filter_applies_shared_where_clause():
-    class FakeCursor:
-        def __init__(self):
-            self.calls = []
-
-        def execute(self, sql, params):
-            self.calls.append((sql, params))
-
-        def fetchall(self):
-            return []
-
-    class FakeConnection:
-        def __init__(self, cursor):
-            self._cursor = cursor
-
-        def cursor(self):
-            return self._cursor
-
-    fake_cursor = FakeCursor()
-    fake_conn = FakeConnection(fake_cursor)
+    fake_conn, fake_cursor = create_fake_db_connection()
 
     with patch("mcp_server.database._encode_text_to_embedding", return_value=b"fake-embedding"), \
          patch("mcp_server.database.get_connection", return_value=fake_conn), \
@@ -244,25 +231,7 @@ def test_semantic_query_with_date_filter_applies_shared_where_clause():
 
 
 def test_semantic_query_with_is_outbound_filter_applies_shared_where_clause():
-    class FakeCursor:
-        def __init__(self):
-            self.calls = []
-
-        def execute(self, sql, params):
-            self.calls.append((sql, params))
-
-        def fetchall(self):
-            return []
-
-    class FakeConnection:
-        def __init__(self, cursor):
-            self._cursor = cursor
-
-        def cursor(self):
-            return self._cursor
-
-    fake_cursor = FakeCursor()
-    fake_conn = FakeConnection(fake_cursor)
+    fake_conn, fake_cursor = create_fake_db_connection()
 
     with patch("mcp_server.database._encode_text_to_embedding", return_value=b"fake-embedding"), \
          patch("mcp_server.database.get_connection", return_value=fake_conn), \
@@ -279,6 +248,27 @@ def test_semantic_query_with_is_outbound_filter_applies_shared_where_clause():
     assert "e.is_outbound = ?" in sql, f"Expected outbound filter in semantic SQL, got {sql}"
     assert params == [b"fake-embedding", 1, 5], (
         f"Expected semantic params to include outbound filter placeholder, got {params}"
+    )
+
+
+def test_semantic_query_with_is_outbound_false_filter_applies_shared_where_clause():
+    fake_conn, fake_cursor = create_fake_db_connection()
+
+    with patch("mcp_server.database._encode_text_to_embedding", return_value=b"fake-embedding"), \
+         patch("mcp_server.database.get_connection", return_value=fake_conn), \
+         patch("mcp_server.database.close_connection"):
+        result = query_email_database(
+            semantic_query="project update",
+            is_outbound=False,
+            limit=5,
+        )
+
+    assert result["results"] == [], f"Expected empty semantic result set from fake cursor, got {result}"
+    assert len(fake_cursor.calls) == 1, f"Expected exactly one semantic query execution, got {fake_cursor.calls}"
+    sql, params = fake_cursor.calls[0]
+    assert "e.is_outbound = ?" in sql, f"Expected outbound filter in semantic SQL, got {sql}"
+    assert params == [b"fake-embedding", 0, 5], (
+        f"Expected semantic params to normalize outbound false to 0, got {params}"
     )
 
 
@@ -341,6 +331,7 @@ if __name__ == "__main__":
     test_semantic_query_with_filters_applies_shared_where_clause()
     test_semantic_query_with_date_filter_applies_shared_where_clause()
     test_semantic_query_with_is_outbound_filter_applies_shared_where_clause()
+    test_semantic_query_with_is_outbound_false_filter_applies_shared_where_clause()
     test_whitespace_keywords_do_not_enable_fts_join()
     test_limit_is_clamped_to_documented_maximum()
     test_get_embedding_model_returns_initializing_error_without_blocking()

--- a/tests/test_query_extensions.py
+++ b/tests/test_query_extensions.py
@@ -204,6 +204,84 @@ def test_semantic_query_with_filters_applies_shared_where_clause():
     )
 
 
+def test_semantic_query_with_date_filter_applies_shared_where_clause():
+    class FakeCursor:
+        def __init__(self):
+            self.calls = []
+
+        def execute(self, sql, params):
+            self.calls.append((sql, params))
+
+        def fetchall(self):
+            return []
+
+    class FakeConnection:
+        def __init__(self, cursor):
+            self._cursor = cursor
+
+        def cursor(self):
+            return self._cursor
+
+    fake_cursor = FakeCursor()
+    fake_conn = FakeConnection(fake_cursor)
+
+    with patch("mcp_server.database._encode_text_to_embedding", return_value=b"fake-embedding"), \
+         patch("mcp_server.database.get_connection", return_value=fake_conn), \
+         patch("mcp_server.database.close_connection"):
+        result = query_email_database(
+            semantic_query="meeting agenda",
+            date_from="2030-01-01",
+            limit=10,
+        )
+
+    assert result["results"] == [], f"Expected empty semantic result set from fake cursor, got {result}"
+    assert len(fake_cursor.calls) == 1, f"Expected exactly one semantic query execution, got {fake_cursor.calls}"
+    sql, params = fake_cursor.calls[0]
+    assert "e.timestamp >= ?" in sql, f"Expected date filter in semantic SQL, got {sql}"
+    assert params == [b"fake-embedding", "2030-01-01", 10], (
+        f"Expected semantic params to include date filter placeholder, got {params}"
+    )
+
+
+def test_semantic_query_with_is_outbound_filter_applies_shared_where_clause():
+    class FakeCursor:
+        def __init__(self):
+            self.calls = []
+
+        def execute(self, sql, params):
+            self.calls.append((sql, params))
+
+        def fetchall(self):
+            return []
+
+    class FakeConnection:
+        def __init__(self, cursor):
+            self._cursor = cursor
+
+        def cursor(self):
+            return self._cursor
+
+    fake_cursor = FakeCursor()
+    fake_conn = FakeConnection(fake_cursor)
+
+    with patch("mcp_server.database._encode_text_to_embedding", return_value=b"fake-embedding"), \
+         patch("mcp_server.database.get_connection", return_value=fake_conn), \
+         patch("mcp_server.database.close_connection"):
+        result = query_email_database(
+            semantic_query="project update",
+            is_outbound=True,
+            limit=5,
+        )
+
+    assert result["results"] == [], f"Expected empty semantic result set from fake cursor, got {result}"
+    assert len(fake_cursor.calls) == 1, f"Expected exactly one semantic query execution, got {fake_cursor.calls}"
+    sql, params = fake_cursor.calls[0]
+    assert "e.is_outbound = ?" in sql, f"Expected outbound filter in semantic SQL, got {sql}"
+    assert params == [b"fake-embedding", 1, 5], (
+        f"Expected semantic params to include outbound filter placeholder, got {params}"
+    )
+
+
 def test_whitespace_keywords_do_not_enable_fts_join():
     path = create_test_db()
     original_db = Config.DB_PATH
@@ -261,6 +339,8 @@ if __name__ == "__main__":
     test_fts_snippet_query_uses_join_alias()
     test_semantic_query_returns_timeout_error_without_loading_model()
     test_semantic_query_with_filters_applies_shared_where_clause()
+    test_semantic_query_with_date_filter_applies_shared_where_clause()
+    test_semantic_query_with_is_outbound_filter_applies_shared_where_clause()
     test_whitespace_keywords_do_not_enable_fts_join()
     test_limit_is_clamped_to_documented_maximum()
     test_get_embedding_model_returns_initializing_error_without_blocking()


### PR DESCRIPTION
## **User description**
## What
- Add explicit regression coverage proving the semantic query path reuses shared metadata filters
- Cover tag filters, `date_from`, and `is_outbound` in `tests/test_query_extensions.py`

## Why
Issue #33 reported that semantic search silently ignored metadata constraints. The implementation was already corrected as part of issue #31 follow-up work, but this PR adds dedicated issue-focused coverage to lock in that behavior and prevent regressions.

## Testing
- `/Users/thomasmaerz/emailindex/.venv/bin/python -m pytest tests/test_query_extensions.py -q`

Closes #33


___

## **CodeAnt-AI Description**
**Cover semantic search filters for date and outbound messages**

### What Changed
- Added regression tests to confirm semantic search keeps applying shared filters for message date and outbound status
- Verifies the generated query includes the date cutoff when `date_from` is set
- Verifies the generated query includes the outbound-only filter when `is_outbound` is set

### Impact
`✅ Fewer semantic search results that ignore date limits`
`✅ Fewer semantic search results that include the wrong message direction`
`✅ Safer semantic search filtering after future changes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for semantic-search filtering, validating that date-based and direction-based filters produce the expected WHERE predicates and parameter ordering.
  * Introduced a reusable fake DB connection helper to consistently capture and assert executed SQL and bound parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->