### PR TITLE
fix: search_emails() was returning least-similar emails first due to DESC sort (#35)

### DIFF
--- a/mcp_server/database.py
+++ b/mcp_server/database.py
@@ -205,7 +205,7 @@ def search_emails(
                     FROM emails e
                     WHERE e.id != ? AND e.embedding IS NOT NULL
                       AND (e.source IS NULL OR e.source != 'quoted_reply')
-                    ORDER BY score DESC
+                    ORDER BY score ASC
                     LIMIT ?
                 """, (row['embedding'], similar_to_email_id, limit))
                 

--- a/tests/test_query_extensions.py
+++ b/tests/test_query_extensions.py
@@ -30,6 +30,33 @@ def create_fake_db_connection():
     fake_conn = FakeConnection(fake_cursor)
     return fake_conn, fake_cursor
 
+
+def create_fake_search_connection(results, embedding=b"seed-embedding"):
+    class FakeCursor:
+        def __init__(self):
+            self.calls = []
+            self._results = results
+
+        def execute(self, sql, params):
+            self.calls.append((sql, params))
+
+        def fetchone(self):
+            return {"embedding": embedding}
+
+        def fetchall(self):
+            return self._results
+
+    class FakeConnection:
+        def __init__(self, cursor):
+            self._cursor = cursor
+
+        def cursor(self):
+            return self._cursor
+
+    fake_cursor = FakeCursor()
+    fake_conn = FakeConnection(fake_cursor)
+    return fake_conn, fake_cursor
+
 def create_test_db():
     fd, path = tempfile.mkstemp(suffix='.db')
     os.close(fd)
@@ -319,6 +346,47 @@ def test_initialize_embedding_model_async_retries_after_previous_failure():
 
         thread_mock.assert_called_once()
 
+
+def test_search_emails_similarity_order():
+    from mcp_server.database import search_emails
+
+    fake_results = [
+        {
+            "id": "2",
+            "thread_id": "thread-2",
+            "subject": "Less similar",
+            "timestamp": "2024-01-02T00:00:00Z",
+            "from_address": "b@example.com",
+            "from_name": "B",
+            "has_attachments": 0,
+            "folder": "INBOX",
+            "snippet": "snippet-b",
+            "score": 0.9,
+        },
+        {
+            "id": "1",
+            "thread_id": "thread-1",
+            "subject": "More similar",
+            "timestamp": "2024-01-01T00:00:00Z",
+            "from_address": "a@example.com",
+            "from_name": "A",
+            "has_attachments": 0,
+            "folder": "INBOX",
+            "snippet": "snippet-a",
+            "score": 0.1,
+        },
+    ]
+    fake_conn, fake_cursor = create_fake_search_connection(fake_results)
+
+    with patch("mcp_server.database.get_connection", return_value=fake_conn), \
+         patch("mcp_server.database.close_connection"):
+        similar = search_emails(similar_to_email_id="seed-id", limit=5)
+
+    assert len(fake_cursor.calls) == 2, f"Expected embedding lookup and search query, got {fake_cursor.calls}"
+    sql, _ = fake_cursor.calls[1]
+    assert "ORDER BY score ASC" in sql, f"Expected vector similarity ordering by ascending distance, got {sql}"
+    assert [result.id for result in similar] == ["2", "1"], f"Expected fake result order to be preserved, got {similar}"
+
 if __name__ == "__main__":
     test_count_only_returns_count()
     test_sort_by_timestamp_asc()
@@ -336,4 +404,5 @@ if __name__ == "__main__":
     test_limit_is_clamped_to_documented_maximum()
     test_get_embedding_model_returns_initializing_error_without_blocking()
     test_initialize_embedding_model_async_retries_after_previous_failure()
+    test_search_emails_similarity_order()
     print("\n✅ All query extension tests passed!")

--- a/tests/test_query_extensions.py
+++ b/tests/test_query_extensions.py
@@ -352,18 +352,6 @@ def test_search_emails_similarity_order():
 
     fake_results = [
         {
-            "id": "2",
-            "thread_id": "thread-2",
-            "subject": "Less similar",
-            "timestamp": "2024-01-02T00:00:00Z",
-            "from_address": "b@example.com",
-            "from_name": "B",
-            "has_attachments": 0,
-            "folder": "INBOX",
-            "snippet": "snippet-b",
-            "score": 0.9,
-        },
-        {
             "id": "1",
             "thread_id": "thread-1",
             "subject": "More similar",
@@ -375,6 +363,18 @@ def test_search_emails_similarity_order():
             "snippet": "snippet-a",
             "score": 0.1,
         },
+        {
+            "id": "2",
+            "thread_id": "thread-2",
+            "subject": "Less similar",
+            "timestamp": "2024-01-02T00:00:00Z",
+            "from_address": "b@example.com",
+            "from_name": "B",
+            "has_attachments": 0,
+            "folder": "INBOX",
+            "snippet": "snippet-b",
+            "score": 0.9,
+        },
     ]
     fake_conn, fake_cursor = create_fake_search_connection(fake_results)
 
@@ -385,7 +385,8 @@ def test_search_emails_similarity_order():
     assert len(fake_cursor.calls) == 2, f"Expected embedding lookup and search query, got {fake_cursor.calls}"
     sql, _ = fake_cursor.calls[1]
     assert "ORDER BY score ASC" in sql, f"Expected vector similarity ordering by ascending distance, got {sql}"
-    assert [result.id for result in similar] == ["2", "1"], f"Expected fake result order to be preserved, got {similar}"
+    scores = [result.score for result in similar if result.score is not None]
+    assert scores == sorted(scores), f"Expected most-similar-first ordering, got {scores}"
 
 if __name__ == "__main__":
     test_count_only_returns_count()


### PR DESCRIPTION
## **User description**
## What
- Change the vector similarity path in `search_emails()` to sort distances ascending instead of descending
- Add a focused regression test that verifies the generated similarity query orders by `score ASC`

## Why
`vec_distance_cosine` returns distance, where lower values are more similar. Ordering by `DESC` returned the least-similar matches first.

## Testing
- `/Users/thomasmaerz/emailindex/.venv/bin/python -m pytest tests/test_query_extensions.py -q -k "similarity_order or semantic"`

Closes #35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the sorting order for email similarity search results.

* **Tests**
  * Added tests to validate email similarity search ordering, including a deterministic test setup for vector/semantic search.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Show the most similar emails first in similarity search**

### What Changed
- Similar-email search now sorts by lowest distance first, so the closest matches appear at the top
- Added a test that checks the search query uses ascending order and returns results in the expected order

### Impact
`✅ More relevant email matches`
`✅ Fewer confusing search results`
`✅ Faster review of similar emails`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
