### PR TITLE
fix: use indexed from_address column instead of unindexed sender in filter queries (#37)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ The Email Intelligence System parses personal email archives into a queryable SQ
 | Limitation | Impact | Tracking |
 |------------|--------|---------|
 | Vector search (sqlite-vec) uses brute-force scan — no ANN index | ~3-5s per semantic query on 81K emails; degrades linearly | Upstream: https://github.com/asg017/sqlite-vec |
+| `recipients LIKE '%addr%'` uses full table scan | No B-tree index can accelerate leading-wildcard LIKE on JSON array columns. Junction table migration would fix this but is out of scope. | — |
 
 ---
 

--- a/mcp_server/database.py
+++ b/mcp_server/database.py
@@ -484,7 +484,7 @@ def query_email_database(
         where_clauses.append("e.timestamp <= ?")
         params.append(date_to)
     if from_address:
-        where_clauses.append("e.sender = ?")
+        where_clauses.append("e.from_address = ?")
         params.append(from_address)
     if from_name:
         where_clauses.append("e.from_name LIKE ?")
@@ -893,8 +893,8 @@ def get_mention_timeline(
     conn = get_connection()
     cursor = conn.cursor()
 
-    from_clause = "FROM emails e JOIN emails_fts ON e.rowid = emails_fts.rowid"
-    where_clauses = ["emails_fts MATCH ?"]
+    from_clause = "FROM emails e"
+    where_clauses = ["e.rowid IN (SELECT rowid FROM emails_fts WHERE emails_fts MATCH ?)"]
     params: list[object] = [keyword]
 
     if date_from:
@@ -904,7 +904,7 @@ def get_mention_timeline(
         where_clauses.append("e.timestamp <= ?")
         params.append(date_to)
     if from_address:
-        where_clauses.append("e.sender = ?")
+        where_clauses.append("e.from_address = ?")
         params.append(from_address)
     if is_outbound is not None:
         where_clauses.append("e.is_outbound = ?")
@@ -970,8 +970,8 @@ def get_contact_profile(
         where_clauses.append("(e.from_name LIKE ? OR e.sender LIKE ? OR e.recipients LIKE ? OR e.to_addresses LIKE ? OR e.cc_addresses LIKE ?)")
         params.extend([f"%{name}%", f"%{name}%", f"%{name}%", f"%{name}%", f"%{name}%"])
     if email_address:
-        where_clauses.append("(e.sender LIKE ? OR e.recipients LIKE ?)")
-        params.extend([f"%{email_address}%", f"%{email_address}%"])
+        where_clauses.append("(e.from_address = ? OR e.recipients LIKE ?)")
+        params.extend([email_address, f"%{email_address}%"])
 
     if not where_clauses:
         close_connection()

--- a/mcp_server/database.py
+++ b/mcp_server/database.py
@@ -43,7 +43,7 @@ def _build_select_columns(fields):
         "thread_id": "e.thread_id",
         "subject_thread_key": "e.subject_thread_key",
         "timestamp": "e.timestamp",
-        "from_address": "e.sender as from_address",
+        "from_address": "e.from_address as from_address",
         "from_name": "e.from_name",
         "to_addresses": "e.to_addresses",
         "cc_addresses": "e.cc_addresses",
@@ -539,7 +539,7 @@ def query_email_database(
             return {"error": f"Failed to encode semantic query: {e}", "results": []}
 
         sql = f"""
-            SELECT e.id, e.thread_id, e.subject, e.timestamp, e.sender as from_address,
+            SELECT e.id, e.thread_id, e.subject, e.timestamp, e.from_address as from_address,
                    e.from_name, e.category_tags, e.project_tags, e.has_attachments, e.folder,
                    COALESCE(e.body_text, e.body_markdown) as body_text,
                    -- NOTE: This query performs a brute-force full-table scan over email_vectors.
@@ -619,7 +619,7 @@ def query_email_database(
     # Build SELECT columns
     if use_snippet:
         sql = f"""
-                SELECT e.id, e.thread_id, e.subject, e.timestamp, e.sender as from_address,
+                SELECT e.id, e.thread_id, e.subject, e.timestamp, e.from_address as from_address,
                        e.from_name, e.has_attachments, e.folder,
                        snippet(emails_fts, 1, '<mark>', '</mark>', '...', {snippet_length}) as snippet,
                        bm25(emails_fts) as rank
@@ -650,7 +650,7 @@ def query_email_database(
     else:
         if use_fts_join:
             sql = f"""
-                SELECT e.id, e.thread_id, e.subject, e.timestamp, e.sender as from_address,
+                SELECT e.id, e.thread_id, e.subject, e.timestamp, e.from_address as from_address,
                        e.from_name, e.category_tags, e.project_tags, e.has_attachments, e.folder,
                        COALESCE(e.body_text, e.body_markdown) as body_text, bm25(emails_fts) as rank
                 {from_clause}
@@ -660,7 +660,7 @@ def query_email_database(
             """
         else:
             sql = f"""
-                SELECT e.id, e.thread_id, e.subject, e.timestamp, e.sender as from_address,
+                SELECT e.id, e.thread_id, e.subject, e.timestamp, e.from_address as from_address,
                        e.from_name, e.category_tags, e.project_tags, e.has_attachments, e.folder,
                        COALESCE(e.body_text, e.body_markdown) as body_text
                 FROM emails e
@@ -748,7 +748,7 @@ def query_email_database(
 
     if include_full_thread and thread_ids:
         cursor_conn.execute("""
-            SELECT e.id, e.thread_id, e.subject, e.timestamp, e.sender as from_address,
+            SELECT e.id, e.thread_id, e.subject, e.timestamp, e.from_address as from_address,
                    e.body_text
             FROM emails e
             WHERE e.thread_id IN ({})
@@ -820,7 +820,7 @@ def get_project_context(project_name: str, limit: int = 10) -> Optional[dict]:
     }
     
     cursor.execute("""
-        SELECT e.id, e.thread_id, e.subject, e.timestamp, e.sender as from_address,
+        SELECT e.id, e.thread_id, e.subject, e.timestamp, e.from_address as from_address,
                e.category_tags, e.project_tags, e.has_attachments, e.folder,
                COALESCE(e.body_text, e.body_markdown) as body_text
         FROM emails e
@@ -1013,7 +1013,7 @@ def get_contact_profile(
             timeline[row["year"]] = row["count"]
 
     cursor.execute(f"""
-        SELECT e.id, e.thread_id, e.subject, e.timestamp, e.sender as from_address,
+        SELECT e.id, e.thread_id, e.subject, e.timestamp, e.from_address as from_address,
                e.from_name, e.has_attachments, e.folder,
                COALESCE(e.body_text, e.body_markdown) as body_text, e.is_outbound
         FROM emails e WHERE {where_sql} ORDER BY e.timestamp DESC LIMIT ?
@@ -1055,7 +1055,7 @@ def get_thread_arc(
     cursor = conn.cursor()
 
     cursor.execute("""
-        SELECT e.id, e.thread_id, e.subject, e.timestamp, e.sender as from_address,
+        SELECT e.id, e.thread_id, e.subject, e.timestamp, e.from_address as from_address,
                e.from_name, e.is_outbound,
                COALESCE(e.body_text, e.body_markdown) as body_text
         FROM emails e
@@ -1070,7 +1070,7 @@ def get_thread_arc(
     if not rows and thread_id.startswith("thread-"):
         subject_key = thread_id.replace("thread-", "")
         cursor.execute("""
-            SELECT e.id, e.thread_id, e.subject, e.timestamp, e.sender as from_address,
+            SELECT e.id, e.thread_id, e.subject, e.timestamp, e.from_address as from_address,
                    e.from_name, e.is_outbound,
                    COALESCE(e.body_text, e.body_markdown) as body_text
             FROM emails e
@@ -1154,7 +1154,7 @@ def list_threads(
     threads = []
     for row in rows:
         cursor.execute("""
-            SELECT e.id, e.subject, e.timestamp, e.sender as from_address, e.from_name
+            SELECT e.id, e.subject, e.timestamp, e.from_address as from_address, e.from_name
             FROM emails e
             WHERE e.thread_id = ?
               AND (e.source IS NULL OR e.source != 'quoted_reply')

--- a/tests/test_field_projection.py
+++ b/tests/test_field_projection.py
@@ -36,7 +36,7 @@ def create_test_db():
         "2024-01-15T10:00:00Z", "alice@example.com", "Alice Smith",
         '["bob@example.com"]', '["carol@example.com"]', "Project Update",
         "# Full body\n\nThis is a long body with lots of text about the project update.",
-        "Cleaned body text", "INBOX", "alice@example.com", '["bob@example.com", "carol@example.com"]',
+        "Cleaned body text", "INBOX", "legacy-sender@example.com", '["bob@example.com", "carol@example.com"]',
         '["work"]', '["ProjectAlpha"]', 0, "project update"
     ))
     cursor.execute("INSERT INTO emails_fts(rowid, subject, body_markdown) VALUES (last_insert_rowid(), ?, ?)", ("Project Update", "Full body project update"))
@@ -70,6 +70,17 @@ def test_custom_fields_projection():
         r = result["results"][0]
         assert set(r.keys()) == {"id", "timestamp", "from_address", "subject"}
         print("✓ test_custom_fields_projection passed")
+    finally:
+        os.unlink(path)
+
+def test_from_address_projection_uses_from_address_column():
+    """from_address projections should read the from_address column, not sender."""
+    path = create_test_db()
+    try:
+        Config.DB_PATH = Path(path)
+        result = query_email_database(fields=["id", "from_address"])
+        r = result["results"][0]
+        assert r["from_address"] == "alice@example.com"
     finally:
         os.unlink(path)
 
@@ -117,6 +128,7 @@ def test_recipients_in_default():
 if __name__ == "__main__":
     test_default_fields_minimal()
     test_custom_fields_projection()
+    test_from_address_projection_uses_from_address_column()
     test_snippet_only_with_fts()
     test_excluded_fields_never_returned()
     test_recipients_in_default()

--- a/tests/test_query_extensions.py
+++ b/tests/test_query_extensions.py
@@ -4,7 +4,12 @@ from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from mcp_server.database import query_email_database, _get_embedding_model, initialize_embedding_model_async
+from mcp_server.database import (
+    query_email_database,
+    get_mention_timeline,
+    _get_embedding_model,
+    initialize_embedding_model_async,
+)
 from mcp_server.config import Config
 
 
@@ -77,6 +82,7 @@ def create_test_db():
         )
     """)
     cursor.execute("CREATE VIRTUAL TABLE emails_fts USING fts5(subject, body_markdown, content=emails, content_rowid=rowid)")
+    cursor.execute("CREATE INDEX idx_emails_from_address ON emails(from_address)")
 
     emails = [
         ("001", "2013-01-01T10:00:00Z", "john@old.com", "John Doe", "john@old.com", '["me@example.com"]', "Old mention of John", "John Doe discussed the project.", "[]", "[]"),
@@ -108,6 +114,58 @@ def create_test_db():
     conn.commit()
     conn.close()
     return path
+
+
+def capture_sql_calls(path, callback):
+    class LoggingCursor:
+        def __init__(self, inner_cursor, calls):
+            self._inner_cursor = inner_cursor
+            self._calls = calls
+
+        def execute(self, sql, params=()):
+            normalized_params = tuple(params) if params is not None else ()
+            self._calls.append((sql, normalized_params))
+            return self._inner_cursor.execute(sql, params)
+
+        def fetchone(self):
+            return self._inner_cursor.fetchone()
+
+        def fetchall(self):
+            return self._inner_cursor.fetchall()
+
+        def __getattr__(self, name):
+            return getattr(self._inner_cursor, name)
+
+    class LoggingConnection:
+        def __init__(self, inner_conn):
+            self._inner_conn = inner_conn
+            self.calls = []
+
+        def cursor(self):
+            return LoggingCursor(self._inner_conn.cursor(), self.calls)
+
+        def __getattr__(self, name):
+            return getattr(self._inner_conn, name)
+
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    logging_conn = LoggingConnection(conn)
+    try:
+        with patch("mcp_server.database.get_connection", return_value=logging_conn), \
+             patch("mcp_server.database.close_connection"):
+            callback()
+    finally:
+        conn.close()
+
+    return logging_conn.calls
+
+
+def explain_query_plan(path, sql, params):
+    conn = sqlite3.connect(path)
+    try:
+        return conn.execute(f"EXPLAIN QUERY PLAN {sql}", params).fetchall()
+    finally:
+        conn.close()
 
 def test_count_only_returns_count():
     path = create_test_db()
@@ -152,6 +210,52 @@ def test_from_name_filter():
         for r in result["results"]:
             assert "John" in r["from_name"] or "Doe" in r["from_name"], f"from_name mismatch: {r['from_name']}"
         print("✓ test_from_name_filter passed")
+    finally:
+        os.unlink(path)
+
+
+def test_query_email_database_from_address_filter_uses_from_address_index():
+    path = create_test_db()
+    try:
+        sql_calls = capture_sql_calls(
+            path,
+            lambda: query_email_database(from_address="john@old.com", limit=5),
+        )
+        matching_calls = [
+            (sql, params)
+            for sql, params in sql_calls
+            if "e.from_address = ?" in sql and "FROM emails e" in sql
+        ]
+        assert matching_calls, f"Expected query_email_database to filter on e.from_address, got {sql_calls}"
+
+        plan_rows = explain_query_plan(path, matching_calls[0][0], matching_calls[0][1])
+        plan_details = " | ".join(str(row[3]) for row in plan_rows)
+        assert "idx_emails_from_address" in plan_details, (
+            f"Expected idx_emails_from_address in query plan, got {plan_details}"
+        )
+    finally:
+        os.unlink(path)
+
+
+def test_get_mention_timeline_from_address_filter_uses_from_address_index():
+    path = create_test_db()
+    try:
+        sql_calls = capture_sql_calls(
+            path,
+            lambda: get_mention_timeline(keyword="John", from_address="john@old.com", granularity="year"),
+        )
+        matching_calls = [
+            (sql, params)
+            for sql, params in sql_calls
+            if "e.from_address = ?" in sql and "FROM emails e" in sql
+        ]
+        assert matching_calls, f"Expected get_mention_timeline to filter on e.from_address, got {sql_calls}"
+
+        plan_rows = explain_query_plan(path, matching_calls[0][0], matching_calls[0][1])
+        plan_details = " | ".join(str(row[3]) for row in plan_rows)
+        assert "idx_emails_from_address" in plan_details, (
+            f"Expected idx_emails_from_address in timeline query plan, got {plan_details}"
+        )
     finally:
         os.unlink(path)
 


### PR DESCRIPTION
## **User description**
## Summary
- switch sender-based exact filters to indexed `from_address` in MCP query paths
- keep `recipients LIKE` behavior but document its full-scan limitation in `AGENTS.md`
- add query-plan tests proving indexed access for `from_address` filters

## Testing
- `PATH=\"/Users/thomasmaerz/miniconda3/envs/emailindex/bin:$PATH\" HF_HUB_OFFLINE=1 pytest tests/test_query_extensions.py -v -k \"from_address\"`
- `PATH=\"/Users/thomasmaerz/miniconda3/envs/emailindex/bin:$PATH\" HF_HUB_OFFLINE=1 pytest tests/ -x -q`

Closes #37


___

## **CodeAnt-AI Description**
**Use the saved sender address for direct email filters**

### What Changed
- Filters for a sender address now match the saved `from_address` field, so exact sender searches return the intended emails and can use the address index.
- Mention timelines now apply the same address filter while still showing matching messages.
- Contact profiles now match an exact email address against the sender address instead of a broader text search.
- Added checks that confirm these queries use the indexed sender address path.
- Documented that recipient searches with `LIKE` still scan the full table.

### Impact
`✅ Faster sender searches`
`✅ Fewer missed matches in contact profiles`
`✅ Lower query cost for mention timelines`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a known-limitation note describing performance constraints when filtering recipients with leading-wildcard queries over JSON arrays.

* **Refactor**
  * Standardized sender/from-field handling across email queries and adjusted full-text search query patterns for more consistent behavior.

* **Tests**
  * Added tests and utilities to verify query behavior and that database indexing is used as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->