### PR TITLE
fix: project_tags system — 3% coverage from wrong WHERE, LIKE scan timeout, biased discovery sampling (#39)

### DIFF
--- a/classify_emails.py
+++ b/classify_emails.py
@@ -4,6 +4,7 @@
 import json
 import logging
 import os
+import argparse
 import sqlite3
 import time
 from datetime import datetime, timezone
@@ -111,16 +112,20 @@ def call_gemini(prompt: str, max_retries: int = BATCH_RETRIES) -> Optional[str]:
     return None
 
 
-def discover_projects(checkpoint: dict) -> int:
+def discover_projects(checkpoint: dict, reset_registry: bool = False) -> int:
     logger.info("Starting project discovery phase...")
     conn = get_db_connection()
     cursor = conn.cursor()
 
+    if reset_registry:
+        logger.info("Resetting project_registry before discovery")
+        cursor.execute("DELETE FROM project_registry")
+
     cursor.execute("""
-        SELECT DISTINCT subject, COALESCE(NULLIF(body_text, ''), body_plain, body_markdown) AS body_text 
+        SELECT subject, body_text
         FROM emails 
-        WHERE COALESCE(NULLIF(body_text, ''), body_plain, body_markdown) IS NOT NULL AND COALESCE(NULLIF(body_text, ''), body_plain, body_markdown) != ''
-        ORDER BY timestamp DESC
+        WHERE body_text IS NOT NULL AND length(body_text) > 100
+        ORDER BY RANDOM()
         LIMIT 500
     """)
     rows = cursor.fetchall()
@@ -195,7 +200,7 @@ def classify_emails(checkpoint: dict) -> int:
     query = """
         SELECT id, subject, COALESCE(NULLIF(body_text, ''), body_plain, body_markdown) AS body_text, sender, recipients, timestamp
         FROM emails
-        WHERE (category_tags IS NULL OR category_tags = '')
+        WHERE (project_tags IS NULL OR project_tags = '[]' OR project_tags = '')
     """
 
     params = ()
@@ -310,13 +315,13 @@ Output a JSON array with:
     return classified
 
 
-def run_classification():
+def run_classification(reset_registry: bool = False):
     LOG_DIR.mkdir(parents=True, exist_ok=True)
 
     checkpoint = load_checkpoint()
 
     if not checkpoint.get("discover_phase_done"):
-        discover_projects(checkpoint)
+        discover_projects(checkpoint, reset_registry=reset_registry)
         save_checkpoint(checkpoint)
 
     classified_count = 0
@@ -332,5 +337,16 @@ def run_classification():
     logger.info(f"Classification complete! Total classified: {classified_count}")
 
 
+def parse_args():
+    parser = argparse.ArgumentParser(description="Batch classify emails with Gemini")
+    parser.add_argument(
+        "--reset-registry",
+        action="store_true",
+        help="Truncate project_registry before rediscovering projects",
+    )
+    return parser.parse_args()
+
+
 if __name__ == "__main__":
-    run_classification()
+    args = parse_args()
+    run_classification(reset_registry=args.reset_registry)

--- a/classify_emails.py
+++ b/classify_emails.py
@@ -112,7 +112,7 @@ def call_gemini(prompt: str, max_retries: int = BATCH_RETRIES) -> Optional[str]:
     return None
 
 
-def discover_projects(checkpoint: dict, reset_registry: bool = False) -> int:
+def discover_projects(checkpoint: dict, *, reset_registry: bool = False) -> int:
     logger.info("Starting project discovery phase...")
     conn = get_db_connection()
     cursor = conn.cursor()
@@ -130,8 +130,8 @@ def discover_projects(checkpoint: dict, reset_registry: bool = False) -> int:
     """)
     rows = cursor.fetchall()
 
-    subjects = [r["subject"] for r in rows if r["body_text"] and len(r["body_text"]) > 100]
-    bodies = [r["body_text"][:500] for r in rows if r["body_text"] and len(r["body_text"]) > 100]
+    subjects = [r["subject"] for r in rows]
+    bodies = [r["body_text"][:500] for r in rows]
 
     prompt = f"""Analyze these email subjects and body snippets to identify distinct projects, topics, or categories.
 Return a JSON array of project names (max 20) with brief descriptions.
@@ -150,6 +150,7 @@ Output format:
     result = call_gemini(prompt)
     if not result:
         logger.error("Failed to discover projects")
+        conn.rollback()
         conn.close()
         return 0
 
@@ -178,6 +179,7 @@ Output format:
 
     except Exception as e:
         logger.error(f"Failed to parse project discovery result: {e}")
+        conn.rollback()
         conn.close()
         return 0
 
@@ -315,7 +317,7 @@ Output a JSON array with:
     return classified
 
 
-def run_classification(reset_registry: bool = False):
+def run_classification(*, reset_registry: bool = False):
     LOG_DIR.mkdir(parents=True, exist_ok=True)
 
     checkpoint = load_checkpoint()

--- a/mcp_server/database.py
+++ b/mcp_server/database.py
@@ -167,8 +167,7 @@ def close_connection():
 
 def ensure_email_category_fts(cursor: sqlite3.Cursor) -> None:
     cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='email_category_fts'")
-    if cursor.fetchone():
-        return
+    table_exists = cursor.fetchone() is not None
 
     cursor.execute("""
         CREATE VIRTUAL TABLE IF NOT EXISTS email_category_fts USING fts5(
@@ -177,28 +176,47 @@ def ensure_email_category_fts(cursor: sqlite3.Cursor) -> None:
             content='emails'
         )
     """)
-    cursor.execute("""
-        CREATE TRIGGER IF NOT EXISTS emails_ai AFTER INSERT ON emails BEGIN
-            INSERT INTO email_category_fts(rowid, category_tags, project_tags)
-            VALUES (new.rowid, new.category_tags, new.project_tags);
-        END
-    """)
-    cursor.execute("""
-        CREATE TRIGGER IF NOT EXISTS emails_ad AFTER DELETE ON emails BEGIN
-            INSERT INTO email_category_fts(email_category_fts, rowid, category_tags, project_tags)
-            VALUES('delete', old.rowid, old.category_tags, old.project_tags);
-        END
-    """)
-    cursor.execute("""
-        CREATE TRIGGER IF NOT EXISTS emails_au AFTER UPDATE ON emails BEGIN
-            INSERT INTO email_category_fts(email_category_fts, rowid, category_tags, project_tags)
-            VALUES('delete', old.rowid, old.category_tags, old.project_tags);
-            INSERT INTO email_category_fts(rowid, category_tags, project_tags)
-            VALUES (new.rowid, new.category_tags, new.project_tags);
-        END
-    """)
-    cursor.execute("INSERT INTO email_category_fts(email_category_fts) VALUES('rebuild')")
+
+    trigger_definitions = {
+        "emails_ai": """
+            CREATE TRIGGER IF NOT EXISTS emails_ai AFTER INSERT ON emails BEGIN
+                INSERT INTO email_category_fts(rowid, category_tags, project_tags)
+                VALUES (new.rowid, new.category_tags, new.project_tags);
+            END
+        """,
+        "emails_ad": """
+            CREATE TRIGGER IF NOT EXISTS emails_ad AFTER DELETE ON emails BEGIN
+                INSERT INTO email_category_fts(email_category_fts, rowid, category_tags, project_tags)
+                VALUES('delete', old.rowid, old.category_tags, old.project_tags);
+            END
+        """,
+        "emails_au": """
+            CREATE TRIGGER IF NOT EXISTS emails_au AFTER UPDATE ON emails BEGIN
+                INSERT INTO email_category_fts(email_category_fts, rowid, category_tags, project_tags)
+                VALUES('delete', old.rowid, old.category_tags, old.project_tags);
+                INSERT INTO email_category_fts(rowid, category_tags, project_tags)
+                VALUES (new.rowid, new.category_tags, new.project_tags);
+            END
+        """,
+    }
+
+    missing_trigger = False
+    for trigger_name, trigger_sql in trigger_definitions.items():
+        cursor.execute(
+            "SELECT name FROM sqlite_master WHERE type='trigger' AND name = ?",
+            (trigger_name,),
+        )
+        if cursor.fetchone() is None:
+            missing_trigger = True
+        cursor.execute(trigger_sql)
+
+    if not table_exists or missing_trigger:
+        cursor.execute("INSERT INTO email_category_fts(email_category_fts) VALUES('rebuild')")
     cursor.connection.commit()
+
+
+def _escape_fts5_phrase(term: str) -> str:
+    return term.replace("\\", "\\\\").replace('"', '""')
 
 
 def decompress_eml(compressed_bytes: bytes) -> bytes:
@@ -856,7 +874,7 @@ def get_project_context(project_name: str, limit: int = 10) -> Optional[dict]:
         "created_at": row["created_at"]
     }
     
-    fts_query = f'project_tags:"{row["name"]}"'
+    fts_query = f'project_tags:"{_escape_fts5_phrase(row["name"])}"'
 
     cursor.execute("""
         SELECT e.id, e.thread_id, e.subject, e.timestamp, e.from_address as from_address,

--- a/mcp_server/database.py
+++ b/mcp_server/database.py
@@ -165,6 +165,42 @@ def close_connection():
         _thread_local.conn = None
 
 
+def ensure_email_category_fts(cursor: sqlite3.Cursor) -> None:
+    cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='email_category_fts'")
+    if cursor.fetchone():
+        return
+
+    cursor.execute("""
+        CREATE VIRTUAL TABLE IF NOT EXISTS email_category_fts USING fts5(
+            category_tags,
+            project_tags,
+            content='emails'
+        )
+    """)
+    cursor.execute("""
+        CREATE TRIGGER IF NOT EXISTS emails_ai AFTER INSERT ON emails BEGIN
+            INSERT INTO email_category_fts(rowid, category_tags, project_tags)
+            VALUES (new.rowid, new.category_tags, new.project_tags);
+        END
+    """)
+    cursor.execute("""
+        CREATE TRIGGER IF NOT EXISTS emails_ad AFTER DELETE ON emails BEGIN
+            INSERT INTO email_category_fts(email_category_fts, rowid, category_tags, project_tags)
+            VALUES('delete', old.rowid, old.category_tags, old.project_tags);
+        END
+    """)
+    cursor.execute("""
+        CREATE TRIGGER IF NOT EXISTS emails_au AFTER UPDATE ON emails BEGIN
+            INSERT INTO email_category_fts(email_category_fts, rowid, category_tags, project_tags)
+            VALUES('delete', old.rowid, old.category_tags, old.project_tags);
+            INSERT INTO email_category_fts(rowid, category_tags, project_tags)
+            VALUES (new.rowid, new.category_tags, new.project_tags);
+        END
+    """)
+    cursor.execute("INSERT INTO email_category_fts(email_category_fts) VALUES('rebuild')")
+    cursor.connection.commit()
+
+
 def decompress_eml(compressed_bytes: bytes) -> bytes:
     decompressor = zstd.ZstdDecompressor()
     return decompressor.decompress(compressed_bytes)
@@ -800,6 +836,7 @@ def query_email_database(
 def get_project_context(project_name: str, limit: int = 10) -> Optional[dict]:
     conn = get_connection()
     cursor = conn.cursor()
+    ensure_email_category_fts(cursor)
     
     cursor.execute("""
         SELECT name, aliases, summary, created_at
@@ -819,16 +856,19 @@ def get_project_context(project_name: str, limit: int = 10) -> Optional[dict]:
         "created_at": row["created_at"]
     }
     
+    fts_query = f'project_tags:"{row["name"]}"'
+
     cursor.execute("""
         SELECT e.id, e.thread_id, e.subject, e.timestamp, e.from_address as from_address,
                e.category_tags, e.project_tags, e.has_attachments, e.folder,
                COALESCE(e.body_text, e.body_markdown) as body_text
         FROM emails e
-        WHERE e.project_tags LIKE ?
+        JOIN email_category_fts ecf ON e.rowid = ecf.rowid
+        WHERE email_category_fts MATCH ?
           AND (e.source IS NULL OR e.source != 'quoted_reply')
         ORDER BY e.timestamp DESC
         LIMIT ?
-    """, (f"%{row['name']}%", limit))
+    """, (fts_query, limit))
     
     results = []
     for row in cursor.fetchall():

--- a/tests/test_classify_pagination.py
+++ b/tests/test_classify_pagination.py
@@ -7,6 +7,7 @@ import sys
 import sqlite3
 import tempfile
 import unittest
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import patch, MagicMock, mock_open
 
@@ -67,7 +68,7 @@ class TestClassifyEmailsPagination(unittest.TestCase):
         query = """
             SELECT id, subject, COALESCE(NULLIF(body_text, ''), body_plain, body_markdown) AS body, sender, recipients, timestamp
             FROM emails
-            WHERE (category_tags IS NULL OR category_tags = '')
+            WHERE (project_tags IS NULL OR project_tags = '[]' OR project_tags = '')
         """
 
         params = ()
@@ -255,6 +256,189 @@ class TestCheckpointBackwardCompat(unittest.TestCase):
                 self.assertEqual(checkpoint.get("last_email_id"), "some-uuid")
         finally:
             os.unlink(temp_path)
+
+
+class TestProjectTagClassificationSource(unittest.TestCase):
+    """Tests classification source selection and discovery reset behavior."""
+
+    def setUp(self):
+        self.temp_db = tempfile.NamedTemporaryFile(suffix='.db', delete=False)
+        self.temp_db.close()
+        self.conn = sqlite3.connect(self.temp_db.name)
+        self.conn.row_factory = sqlite3.Row
+        self.cursor = self.conn.cursor()
+        self.cursor.execute("""
+            CREATE TABLE emails (
+                id TEXT PRIMARY KEY,
+                subject TEXT NOT NULL,
+                body_text TEXT,
+                body_markdown TEXT,
+                body_plain TEXT,
+                sender TEXT,
+                recipients TEXT,
+                timestamp TEXT NOT NULL,
+                category_tags TEXT,
+                project_tags TEXT
+            )
+        """)
+        self.cursor.execute("""
+            CREATE TABLE project_registry (
+                name TEXT PRIMARY KEY,
+                aliases TEXT,
+                summary TEXT,
+                created_at TEXT
+            )
+        """)
+        self.conn.commit()
+
+    def tearDown(self):
+        self.conn.close()
+        os.unlink(self.temp_db.name)
+
+    def test_query_targets_missing_project_tags_not_category_tags(self):
+        self.cursor.execute(
+            "INSERT INTO project_registry (name, aliases, summary, created_at) VALUES (?, ?, ?, ?)",
+            ("Alpha", "", "alpha project", "2024-01-01T00:00:00Z"),
+        )
+        self.cursor.execute(
+            """
+            INSERT INTO emails (id, subject, body_text, body_markdown, body_plain, sender, recipients, timestamp, category_tags, project_tags)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            ("needs-project-tags", "Tagged category only", "body" * 50, "", "", "a@test.com", "b@test.com", "2024-01-01T00:00:00Z", '["work"]', '[]'),
+        )
+        self.cursor.execute(
+            """
+            INSERT INTO emails (id, subject, body_text, body_markdown, body_plain, sender, recipients, timestamp, category_tags, project_tags)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            ("already-has-project-tags", "Has project tag", "body" * 50, "", "", "a@test.com", "b@test.com", "2024-01-02T00:00:00Z", None, '["Alpha"]'),
+        )
+        self.conn.commit()
+
+        checkpoint = {"last_timestamp": None, "last_email_id": None, "emails_classified": 0}
+
+        with patch.object(ce, 'DB_PATH', Path(self.temp_db.name)), \
+             patch.object(ce, 'BATCH_SIZE', 100), \
+             patch.object(ce, 'call_gemini', return_value=json.dumps([
+                 {"id": "needs-project-tags", "category_tags": "work", "project_tags": "Alpha"}
+             ])):
+            classified = ce.classify_emails(checkpoint)
+
+        self.assertEqual(classified, 1)
+
+        self.cursor.execute("SELECT project_tags FROM emails WHERE id = ?", ("needs-project-tags",))
+        self.assertEqual(self.cursor.fetchone()[0], '["Alpha"]')
+
+        self.cursor.execute("SELECT project_tags FROM emails WHERE id = ?", ("already-has-project-tags",))
+        self.assertEqual(self.cursor.fetchone()[0], '["Alpha"]')
+
+    def test_discover_projects_reset_registry_truncates_before_insert(self):
+        self.cursor.execute(
+            "INSERT INTO project_registry (name, aliases, summary, created_at) VALUES (?, ?, ?, ?)",
+            ("Legacy", "", "old", "2024-01-01T00:00:00Z"),
+        )
+        self.cursor.execute(
+            """
+            INSERT INTO emails (id, subject, body_text, body_markdown, body_plain, sender, recipients, timestamp, category_tags, project_tags)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            ("sample", "Discovery sample", "x" * 200, "", "", "a@test.com", "b@test.com", "2024-01-01T00:00:00Z", None, None),
+        )
+        self.conn.commit()
+
+        checkpoint = {"discover_phase_done": False, "projects_discovered": 0}
+
+        with patch.object(ce, 'DB_PATH', Path(self.temp_db.name)), \
+             patch.object(ce, 'call_gemini', return_value=json.dumps([
+                 {"name": "Fresh", "aliases": ["NewAlias"], "summary": "new"}
+             ])):
+            discovered = ce.discover_projects(checkpoint, reset_registry=True)
+
+        self.assertEqual(discovered, 1)
+        self.cursor.execute("SELECT name FROM project_registry ORDER BY name")
+        self.assertEqual([row[0] for row in self.cursor.fetchall()], ["Fresh"])
+
+
+class TestProjectContextFTS(unittest.TestCase):
+    """Tests project context uses FTS-backed project tag lookup."""
+
+    def setUp(self):
+        self.temp_db = tempfile.NamedTemporaryFile(suffix='.db', delete=False)
+        self.temp_db.close()
+        self.conn = sqlite3.connect(self.temp_db.name)
+        self.cursor = self.conn.cursor()
+        self.cursor.execute("""
+            CREATE TABLE emails (
+                id TEXT PRIMARY KEY,
+                thread_id TEXT,
+                subject TEXT,
+                timestamp TEXT,
+                from_address TEXT,
+                category_tags TEXT,
+                project_tags TEXT,
+                has_attachments INTEGER,
+                folder TEXT,
+                body_text TEXT,
+                body_markdown TEXT,
+                source TEXT
+            )
+        """)
+        self.cursor.execute("""
+            CREATE TABLE project_registry (
+                name TEXT PRIMARY KEY,
+                aliases TEXT,
+                summary TEXT,
+                created_at TEXT
+            )
+        """)
+        self.cursor.execute(
+            "INSERT INTO project_registry (name, aliases, summary, created_at) VALUES (?, ?, ?, ?)",
+            ("Alpha", "A1", "alpha summary", datetime.now(timezone.utc).isoformat()),
+        )
+        self.cursor.executemany(
+            """
+            INSERT INTO emails (id, thread_id, subject, timestamp, from_address, category_tags, project_tags, has_attachments, folder, body_text, body_markdown, source)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                ("exact", "thread-1", "Exact match", "2024-01-02T00:00:00Z", "a@test.com", '["work"]', '["Alpha"]', 0, "INBOX", "exact body", None, "original"),
+                ("partial", "thread-2", "Partial only", "2024-01-03T00:00:00Z", "b@test.com", '["work"]', '["AlphaX"]', 0, "INBOX", "partial body", None, "original"),
+            ],
+        )
+        self.cursor.execute("""
+            CREATE VIRTUAL TABLE email_category_fts USING fts5(
+                category_tags,
+                project_tags,
+                content='emails'
+            )
+        """)
+        self.cursor.execute("INSERT INTO email_category_fts(email_category_fts) VALUES('rebuild')")
+        self.conn.commit()
+
+    def tearDown(self):
+        from mcp_server import database as db
+
+        db.close_connection()
+        self.conn.close()
+        os.unlink(self.temp_db.name)
+
+    def test_get_project_context_uses_exact_project_tag_fts_match(self):
+        from mcp_server.config import Config
+        from mcp_server import database as db
+
+        original_db = Config.DB_PATH
+        try:
+            Config.DB_PATH = Path(self.temp_db.name)
+            db.close_connection()
+            result = db.get_project_context("Alpha", limit=10)
+        finally:
+            db.close_connection()
+            Config.DB_PATH = original_db
+
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual([email["id"] for email in result["emails"]], ["exact"])
 
 
 class TestParameterizedQuery(unittest.TestCase):

--- a/tests/test_classify_pagination.py
+++ b/tests/test_classify_pagination.py
@@ -262,9 +262,11 @@ class TestProjectTagClassificationSource(unittest.TestCase):
     """Tests classification source selection and discovery reset behavior."""
 
     def setUp(self):
-        self.temp_db = tempfile.NamedTemporaryFile(suffix='.db', delete=False)
-        self.temp_db.close()
-        self.conn = sqlite3.connect(self.temp_db.name)
+        temp_db = tempfile.NamedTemporaryFile(suffix='.db', delete=False)
+        self.addCleanup(lambda path=temp_db.name: os.path.exists(path) and os.unlink(path))
+        temp_db.close()
+        self.temp_db = temp_db.name
+        self.conn = sqlite3.connect(self.temp_db)
         self.conn.row_factory = sqlite3.Row
         self.cursor = self.conn.cursor()
         self.cursor.execute("""
@@ -293,7 +295,6 @@ class TestProjectTagClassificationSource(unittest.TestCase):
 
     def tearDown(self):
         self.conn.close()
-        os.unlink(self.temp_db.name)
 
     def test_query_targets_missing_project_tags_not_category_tags(self):
         self.cursor.execute(
@@ -318,14 +319,19 @@ class TestProjectTagClassificationSource(unittest.TestCase):
 
         checkpoint = {"last_timestamp": None, "last_email_id": None, "emails_classified": 0}
 
-        with patch.object(ce, 'DB_PATH', Path(self.temp_db.name)), \
+        gemini_response = json.dumps([
+            {"id": "needs-project-tags", "category_tags": "work", "project_tags": "Alpha"}
+        ])
+
+        with patch.object(ce, 'DB_PATH', Path(self.temp_db)), \
              patch.object(ce, 'BATCH_SIZE', 100), \
-             patch.object(ce, 'call_gemini', return_value=json.dumps([
-                 {"id": "needs-project-tags", "category_tags": "work", "project_tags": "Alpha"}
-             ])):
+             patch.object(ce, 'call_gemini', return_value=gemini_response) as mock_call_gemini:
             classified = ce.classify_emails(checkpoint)
 
         self.assertEqual(classified, 1)
+        prompt = mock_call_gemini.call_args.args[0]
+        self.assertIn('"id": "needs-project-tags"', prompt)
+        self.assertNotIn('"id": "already-has-project-tags"', prompt)
 
         self.cursor.execute("SELECT project_tags FROM emails WHERE id = ?", ("needs-project-tags",))
         self.assertEqual(self.cursor.fetchone()[0], '["Alpha"]')
@@ -349,24 +355,50 @@ class TestProjectTagClassificationSource(unittest.TestCase):
 
         checkpoint = {"discover_phase_done": False, "projects_discovered": 0}
 
-        with patch.object(ce, 'DB_PATH', Path(self.temp_db.name)), \
+        with patch.object(ce, 'DB_PATH', Path(self.temp_db)), \
              patch.object(ce, 'call_gemini', return_value=json.dumps([
-                 {"name": "Fresh", "aliases": ["NewAlias"], "summary": "new"}
-             ])):
+                  {"name": "Fresh", "aliases": ["NewAlias"], "summary": "new"}
+              ])):
             discovered = ce.discover_projects(checkpoint, reset_registry=True)
 
         self.assertEqual(discovered, 1)
         self.cursor.execute("SELECT name FROM project_registry ORDER BY name")
         self.assertEqual([row[0] for row in self.cursor.fetchall()], ["Fresh"])
 
+    def test_discover_projects_reset_registry_rolls_back_on_parse_failure(self):
+        self.cursor.execute(
+            "INSERT INTO project_registry (name, aliases, summary, created_at) VALUES (?, ?, ?, ?)",
+            ("Legacy", "", "old", "2024-01-01T00:00:00Z"),
+        )
+        self.cursor.execute(
+            """
+            INSERT INTO emails (id, subject, body_text, body_markdown, body_plain, sender, recipients, timestamp, category_tags, project_tags)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            ("sample", "Discovery sample", "x" * 200, "", "", "a@test.com", "b@test.com", "2024-01-01T00:00:00Z", None, None),
+        )
+        self.conn.commit()
+
+        checkpoint = {"discover_phase_done": False, "projects_discovered": 0}
+
+        with patch.object(ce, 'DB_PATH', Path(self.temp_db)), \
+             patch.object(ce, 'call_gemini', return_value='not-json'):
+            discovered = ce.discover_projects(checkpoint, reset_registry=True)
+
+        self.assertEqual(discovered, 0)
+        self.cursor.execute("SELECT name FROM project_registry ORDER BY name")
+        self.assertEqual([row[0] for row in self.cursor.fetchall()], ["Legacy"])
+
 
 class TestProjectContextFTS(unittest.TestCase):
     """Tests project context uses FTS-backed project tag lookup."""
 
     def setUp(self):
-        self.temp_db = tempfile.NamedTemporaryFile(suffix='.db', delete=False)
-        self.temp_db.close()
-        self.conn = sqlite3.connect(self.temp_db.name)
+        temp_db = tempfile.NamedTemporaryFile(suffix='.db', delete=False)
+        self.addCleanup(lambda path=temp_db.name: os.path.exists(path) and os.unlink(path))
+        temp_db.close()
+        self.temp_db = temp_db.name
+        self.conn = sqlite3.connect(self.temp_db)
         self.cursor = self.conn.cursor()
         self.cursor.execute("""
             CREATE TABLE emails (
@@ -421,7 +453,6 @@ class TestProjectContextFTS(unittest.TestCase):
 
         db.close_connection()
         self.conn.close()
-        os.unlink(self.temp_db.name)
 
     def test_get_project_context_uses_exact_project_tag_fts_match(self):
         from mcp_server.config import Config
@@ -429,7 +460,7 @@ class TestProjectContextFTS(unittest.TestCase):
 
         original_db = Config.DB_PATH
         try:
-            Config.DB_PATH = Path(self.temp_db.name)
+            Config.DB_PATH = Path(self.temp_db)
             db.close_connection()
             result = db.get_project_context("Alpha", limit=10)
         finally:
@@ -439,6 +470,52 @@ class TestProjectContextFTS(unittest.TestCase):
         self.assertIsNotNone(result)
         assert result is not None
         self.assertEqual([email["id"] for email in result["emails"]], ["exact"])
+
+    def test_ensure_email_category_fts_recreates_missing_triggers(self):
+        from mcp_server import database as db
+
+        self.cursor.execute("DROP TRIGGER IF EXISTS emails_ai")
+        self.cursor.execute("DROP TRIGGER IF EXISTS emails_ad")
+        self.cursor.execute("DROP TRIGGER IF EXISTS emails_au")
+        self.conn.commit()
+
+        db.ensure_email_category_fts(self.cursor)
+
+        self.cursor.execute(
+            "SELECT name FROM sqlite_master WHERE type='trigger' AND name IN ('emails_ai', 'emails_ad', 'emails_au') ORDER BY name"
+        )
+        self.assertEqual([row[0] for row in self.cursor.fetchall()], ["emails_ad", "emails_ai", "emails_au"])
+
+    def test_get_project_context_escapes_fts_special_characters(self):
+        from mcp_server.config import Config
+        from mcp_server import database as db
+
+        self.cursor.execute(
+            "INSERT INTO project_registry (name, aliases, summary, created_at) VALUES (?, ?, ?, ?)",
+            ('Alpha "Beta"', '', 'quoted project', datetime.now(timezone.utc).isoformat()),
+        )
+        self.cursor.execute(
+            """
+            INSERT INTO emails (id, thread_id, subject, timestamp, from_address, category_tags, project_tags, has_attachments, folder, body_text, body_markdown, source)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            ("quoted", "thread-3", "Quoted project", "2024-01-04T00:00:00Z", "c@test.com", '["work"]', '["Alpha \"Beta\""]', 0, "INBOX", "quoted body", None, "original"),
+        )
+        self.cursor.execute("INSERT INTO email_category_fts(email_category_fts) VALUES('rebuild')")
+        self.conn.commit()
+
+        original_db = Config.DB_PATH
+        try:
+            Config.DB_PATH = Path(self.temp_db)
+            db.close_connection()
+            result = db.get_project_context('Alpha "Beta"', limit=10)
+        finally:
+            db.close_connection()
+            Config.DB_PATH = original_db
+
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual([email["id"] for email in result["emails"]], ["quoted"])
 
 
 class TestParameterizedQuery(unittest.TestCase):


### PR DESCRIPTION
## Summary
- fix classification to target missing `project_tags` instead of `category_tags`
- replace `get_project_context` project-tag LIKE scan with FTS5 matching via `email_category_fts`
- distribute project discovery sampling and add `--reset-registry` to avoid stale registry buildup

## Testing
- `PATH=\"/Users/thomasmaerz/miniconda3/envs/emailindex/bin:$PATH\" HF_HUB_OFFLINE=1 pytest tests/ -v -k \"project_tags or classify\"`
- `PATH=\"/Users/thomasmaerz/miniconda3/envs/emailindex/bin:$PATH\" HF_HUB_OFFLINE=1 pytest tests/ -x -q`

Closes #39

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI flag to reset the project registry during discovery
  * Automatic full-text index recreation when index/triggers are missing

* **Improvements**
  * More targeted email selection for classification based on project-tag status
  * Faster, more accurate project-context lookup using full-text matching
  * Better source-email sampling for discovery

* **Bug Fixes**
  * Improved error handling with safe rollback during discovery failures

* **Tests**
  * Added tests for project-tag-driven classification, registry reset behavior, and FTS-based project context
<!-- end of auto-generated comment: release notes by coderabbit.ai -->